### PR TITLE
feat: enable to set github repository for a project

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -752,55 +752,6 @@ paths:
           $ref: '#/components/responses/ForbiddenErrorResponse'
         '404':
           $ref: '#/components/responses/NotFoundErrorResponse'
-  /projects/{project-id}/repository:
-    put:
-      summary: 'Connect SCM repository'
-      security:
-        - bearerAuth: [ ]
-      tags:
-        - SCM repository
-      parameters:
-        - $ref: '#/components/parameters/ProjectIdParam'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GitRepositoryRequest'
-      responses:
-        '200':
-          description: 'Repository connected'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GitRepositoryResponse'
-        '401':
-          $ref: '#/components/responses/GitRepositoryUnauthorizedErrorResponse'
-        '403':
-          $ref: '#/components/responses/ForbiddenErrorResponse'
-        '404':
-          $ref: '#/components/responses/NotFoundErrorResponse'
-        '422':
-          $ref: '#/components/responses/UnprocesssableEntityResponse'
-    get:
-      summary: 'Get connected repository'
-      security:
-        - bearerAuth: [ ]
-      tags:
-        - SCM repository
-      parameters:
-        - $ref: '#/components/parameters/ProjectIdParam'
-      responses:
-        '200':
-          description: 'Repository fetched'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GitRepositoryResponse'
-        '401':
-          $ref: '#/components/responses/GitRepositoryUnauthorizedErrorResponse'
-        '404':
-          $ref: '#/components/responses/NotFoundErrorResponse'
   /projects/{project-id}/repository/tags:
     get:
       summary: 'List repository tags'
@@ -1062,6 +1013,10 @@ components:
             show_source_code:
               type: boolean
               default: false
+        github_repository_url:
+          type: string
+          format: url
+          example: "htttp://github.com/owner/repo"
       required:
         - name
     ProjectResponse:
@@ -1149,43 +1104,6 @@ components:
         - status
         - created_at
         - updated_at
-    GitRepositoryRequest:
-      type: object
-      properties:
-        platform:
-          type: string
-          enum:
-            - github
-        repository:
-          type: object
-          properties:
-            url:
-              type: string
-              example: 'https://github.com/organization/repo'
-          required:
-            - url
-      required:
-        - platform
-        - repository
-    GitRepositoryResponse:
-      type: object
-      properties:
-        platform:
-          type: string
-          enum:
-            - github
-        repository:
-          type: object
-          properties:
-            url:
-              type: string
-              example: 'https://github.com/organization/repo'
-            name:
-              type: string
-              example: 'Hello-world'
-          required:
-            - url
-            - name
     EnvironmentRequest:
       type: object
       properties:

--- a/repository/project.go
+++ b/repository/project.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 
+	"release-manager/pkg/dberrors"
 	"release-manager/repository/model"
 	"release-manager/repository/util"
 	svcmodel "release-manager/service/model"
@@ -48,7 +49,12 @@ func (r *ProjectRepository) Read(ctx context.Context, id uuid.UUID) (svcmodel.Pr
 		return svcmodel.Project{}, util.ToDBError(err)
 	}
 
-	return model.ToSvcProject(resp), nil
+	p, err := model.ToSvcProject(resp)
+	if err != nil {
+		return svcmodel.Project{}, dberrors.NewToSvcModelError().Wrap(err)
+	}
+
+	return p, nil
 }
 
 func (r *ProjectRepository) ReadAll(ctx context.Context) ([]svcmodel.Project, error) {
@@ -61,7 +67,12 @@ func (r *ProjectRepository) ReadAll(ctx context.Context) ([]svcmodel.Project, er
 		return nil, util.ToDBError(err)
 	}
 
-	return model.ToSvcProjects(resp), nil
+	p, err := model.ToSvcProjects(resp)
+	if err != nil {
+		return nil, dberrors.NewToSvcModelError().Wrap(err)
+	}
+
+	return p, nil
 }
 
 func (r *ProjectRepository) Delete(ctx context.Context, id uuid.UUID) error {

--- a/service/model/project_test.go
+++ b/service/model/project_test.go
@@ -31,6 +31,46 @@ func TestProject_NewProject(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Invalid Project - invalid github repository url - not absolute url",
+			creation: CreateProjectInput{
+				Name:                      "",
+				SlackChannelID:            "channelID",
+				ReleaseNotificationConfig: ReleaseNotificationConfig{Message: "Test Message"},
+				GithubRepositoryRawURL:    "invalid/url",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Project - invalid github repository url - not github host",
+			creation: CreateProjectInput{
+				Name:                      "",
+				SlackChannelID:            "channelID",
+				ReleaseNotificationConfig: ReleaseNotificationConfig{Message: "Test Message"},
+				GithubRepositoryRawURL:    "https://google.com/url/url",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Project - invalid github repository url - not repository url #1",
+			creation: CreateProjectInput{
+				Name:                      "",
+				SlackChannelID:            "channelID",
+				ReleaseNotificationConfig: ReleaseNotificationConfig{Message: "Test Message"},
+				GithubRepositoryRawURL:    "https://github.com/owner",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Project - invalid github repository url - not repository url #2",
+			creation: CreateProjectInput{
+				Name:                      "",
+				SlackChannelID:            "channelID",
+				ReleaseNotificationConfig: ReleaseNotificationConfig{Message: "Test Message"},
+				GithubRepositoryRawURL:    "https://github.com/owner/repo/pr",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -51,6 +91,11 @@ func TestProject_Update(t *testing.T) {
 	newValidName := "New Name"
 	newInvalidName := ""
 	newSlackChannelID := "newChannelID"
+
+	githubInvalidURL := "invalid/url"
+	githubInvalidHost := "https://google.com/url/url"
+	githubInvalidRepoURL1 := "https://github.com/owner"
+	githubInvalidRepoURL2 := "https://github.com/owner/repo/pr"
 
 	tests := []struct {
 		name    string
@@ -81,6 +126,62 @@ func TestProject_Update(t *testing.T) {
 			update: UpdateProjectInput{
 				Name:           &newInvalidName,
 				SlackChannelID: &newSlackChannelID,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Update - invalid github repository url - not absolute url",
+			project: Project{
+				ID:             uuid.New(),
+				Name:           oldName,
+				SlackChannelID: oldSlackChannelID,
+			},
+			update: UpdateProjectInput{
+				Name:                   &newInvalidName,
+				SlackChannelID:         &newSlackChannelID,
+				GithubRepositoryRawURL: &githubInvalidURL,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Update - invalid github repository url - not github host",
+			project: Project{
+				ID:             uuid.New(),
+				Name:           oldName,
+				SlackChannelID: oldSlackChannelID,
+			},
+			update: UpdateProjectInput{
+				Name:                   &newInvalidName,
+				SlackChannelID:         &newSlackChannelID,
+				GithubRepositoryRawURL: &githubInvalidHost,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Update - invalid github repository url - not repository url #1",
+			project: Project{
+				ID:             uuid.New(),
+				Name:           oldName,
+				SlackChannelID: oldSlackChannelID,
+			},
+			update: UpdateProjectInput{
+				Name:                   &newInvalidName,
+				SlackChannelID:         &newSlackChannelID,
+				GithubRepositoryRawURL: &githubInvalidRepoURL1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Update - invalid github repository url - not repository url #2",
+			project: Project{
+				ID:             uuid.New(),
+				Name:           oldName,
+				SlackChannelID: oldSlackChannelID,
+			},
+			update: UpdateProjectInput{
+				Name:                   &newInvalidName,
+				SlackChannelID:         &newSlackChannelID,
+				GithubRepositoryRawURL: &githubInvalidRepoURL2,
 			},
 			wantErr: true,
 		},

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -47,6 +47,19 @@ func TestProjectService_Create(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Invalid project - invalid github repository url",
+			project: model.CreateProjectInput{
+				Name:                      "",
+				SlackChannelID:            "",
+				ReleaseNotificationConfig: model.ReleaseNotificationConfig{},
+				GithubRepositoryRawURL:    "https://github.com/owner",
+			},
+			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository, envRepo *repo.EnvironmentRepository) {
+				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -181,6 +194,7 @@ func TestProjectService_Update(t *testing.T) {
 	validProjectName := "Project name"
 	invalidProjectName := ""
 	slackChannelID := "channelID"
+	invalidGithubRepositoryURL := "https://github.com/owner"
 
 	testCases := []struct {
 		name      string
@@ -207,6 +221,26 @@ func TestProjectService_Update(t *testing.T) {
 				projectRepo.On("Update", mock.Anything, mock.Anything).Return(model.Project{}, nil)
 			},
 			wantErr: false,
+		},
+		{
+			name: "Invalid project update - invalid github repository url",
+			update: model.UpdateProjectInput{
+				Name:           &validProjectName,
+				SlackChannelID: &slackChannelID,
+				ReleaseNotificationConfigUpdate: model.UpdateReleaseNotificationConfigInput{
+					Message:         new(string),
+					ShowProjectName: new(bool),
+					ShowReleaseName: new(bool),
+					ShowChangelog:   new(bool),
+					ShowDeployments: new(bool),
+					ShowSourceCode:  new(bool),
+				},
+				GithubRepositoryRawURL: &invalidGithubRepositoryURL,
+			},
+			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository, envRepo *repo.EnvironmentRepository) {
+				projectRepo.On("Read", mock.Anything, mock.Anything).Return(model.Project{}, nil)
+			},
+			wantErr: true,
 		},
 		{
 			name: "Invalid project update - missing name",

--- a/supabase/migrations/20240427062850_projects_github_repository.sql
+++ b/supabase/migrations/20240427062850_projects_github_repository.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.projects
+ADD COLUMN github_repository JSON;

--- a/transport/model/project.go
+++ b/transport/model/project.go
@@ -12,12 +12,14 @@ type CreateProjectInput struct {
 	Name                      string                    `json:"name"`
 	SlackChannelID            string                    `json:"slack_channel_id"`
 	ReleaseNotificationConfig ReleaseNotificationConfig `json:"release_notification_config"`
+	GithubRepositoryURL       string                    `json:"github_repository_url"`
 }
 
 type UpdateProjectInput struct {
 	Name                      *string                              `json:"name"`
 	SlackChannelID            *string                              `json:"slack_channel_id"`
 	ReleaseNotificationConfig UpdateReleaseNotificationConfigInput `json:"release_notification_config"`
+	GithubRepositoryURL       *string                              `json:"github_repository_url"`
 }
 
 type Project struct {
@@ -25,6 +27,7 @@ type Project struct {
 	Name                      string                    `json:"name"`
 	SlackChannelID            string                    `json:"slack_channel_id"`
 	ReleaseNotificationConfig ReleaseNotificationConfig `json:"release_notification_config"`
+	GithubRepository          string                    `json:"github_repository_url"`
 	CreatedAt                 time.Time                 `json:"created_at"`
 	UpdatedAt                 time.Time                 `json:"updated_at"`
 }
@@ -52,6 +55,7 @@ func ToSvcCreateProjectInput(c CreateProjectInput) svcmodel.CreateProjectInput {
 		Name:                      c.Name,
 		SlackChannelID:            c.SlackChannelID,
 		ReleaseNotificationConfig: svcmodel.ReleaseNotificationConfig(c.ReleaseNotificationConfig),
+		GithubRepositoryRawURL:    c.GithubRepositoryURL,
 	}
 }
 
@@ -60,6 +64,7 @@ func ToSvcUpdateProjectInput(u UpdateProjectInput) svcmodel.UpdateProjectInput {
 		Name:                            u.Name,
 		SlackChannelID:                  u.SlackChannelID,
 		ReleaseNotificationConfigUpdate: svcmodel.UpdateReleaseNotificationConfigInput(u.ReleaseNotificationConfig),
+		GithubRepositoryRawURL:          u.GithubRepositoryURL,
 	}
 }
 
@@ -69,6 +74,7 @@ func ToProject(p svcmodel.Project) Project {
 		Name:                      p.Name,
 		SlackChannelID:            p.SlackChannelID,
 		ReleaseNotificationConfig: ReleaseNotificationConfig(p.ReleaseNotificationConfig),
+		GithubRepository:          p.GithubRepository.URL.String(),
 		CreatedAt:                 p.CreatedAt.Local(),
 		UpdatedAt:                 p.UpdatedAt.Local(),
 	}


### PR DESCRIPTION
To keep PRs smaller, this one only adds the possibility to set a GitHub repo for the project. Accessing the GitHub API (using the [GitHub Go client](https://github.com/google/go-github)) will be handled in upcoming PRs
 
Originally, we wanted to create a separate endpoint for setting a project's GitHub repository. However, I've realized that it isn’t necessary and that it would be much simpler to handle this as part of the project creation and update process.

I was also considering implementing some sort of abstraction. Instead of having a `GithubRepository`, we could use something like `SCMRepository` in case we decide to add GitLab integration or other platforms. However, I think it’s better to keep it simple for now and then refactor it once it’s necessary and we have all the information needed to do the abstraction correctly.