### PR TITLE
feat: introduce release draft

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -2,9 +2,11 @@ package github
 
 import (
 	"context"
+	"fmt"
 
 	"release-manager/github/model"
 	"release-manager/github/util"
+	"release-manager/pkg/githuberrors"
 	svcmodel "release-manager/service/model"
 
 	"github.com/google/go-github/v60/github"
@@ -24,14 +26,14 @@ func NewClient() *Client {
 	}
 }
 
-func (c *Client) SetToken(token string) {
-	c.client = c.client.WithAuthToken(token)
+func (c *Client) RefreshClientWithToken(token string) {
+	c.client = github.NewClient(nil).WithAuthToken(token)
 }
 
 func (c *Client) ListTagsForRepository(ctx context.Context, repo svcmodel.GithubRepository) ([]svcmodel.GitTag, error) {
 	// Up to 100 tags can be fetched per page
 	// If the number of pages is not specified in the list options, only one page will be fetched
-	// https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
+	// Docs https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
 	t, _, err := c.client.Repositories.ListTags(
 		ctx,
 		repo.OwnerSlug,
@@ -43,4 +45,97 @@ func (c *Client) ListTagsForRepository(ctx context.Context, repo svcmodel.Github
 	}
 
 	return model.ToSvcGitTags(t), nil
+}
+
+func (c *Client) CreateReleaseDraft(ctx context.Context, repo svcmodel.GithubRepository, input svcmodel.CreateReleaseDraftInput) (svcmodel.ReleaseDraft, error) {
+	n, err := c.generateReleaseNotes(ctx, repo, input)
+	if err != nil {
+		return svcmodel.ReleaseDraft{}, fmt.Errorf("failed to generate release notes: %w", err)
+	}
+	draft := svcmodel.NewDraftRelease(n.ReleaseName, n.ReleaseNotes)
+
+	t, err := c.getTagByName(ctx, repo, input.TagName)
+	if err != nil && !githuberrors.IsNotFoundError(err) {
+		return svcmodel.ReleaseDraft{}, fmt.Errorf("failed to get tag by name: %w", err)
+	}
+	if githuberrors.IsNotFoundError(err) {
+		draft.LinkSourceCodeByNewTag(
+			model.ToSvcGitTagInput(input.TagName, input.TargetCommitish),
+		)
+
+		// If the tag does not exist yet, there is no need to check if GitHub release exists
+		return draft, nil
+	}
+	draft.LinkSourceCodeByExistingTag(t)
+
+	r, err := c.getReleaseByTag(ctx, repo, input.TagName)
+	if err != nil && !githuberrors.IsNotFoundError(err) {
+		return svcmodel.ReleaseDraft{}, fmt.Errorf("failed to get release by tag: %w", err)
+	}
+	if githuberrors.IsNotFoundError(err) {
+		return draft, nil
+	}
+	draft.AddGithubRelease(r)
+
+	return draft, nil
+}
+
+func (c *Client) getTagByName(ctx context.Context, repo svcmodel.GithubRepository, tagName string) (svcmodel.GitTag, error) {
+	// Git tag can be fetched only by its SHA, using GET /repos/{owner}/{repo}/git/tags/{tag_sha}
+	// Another limitation is that only annotated tags can be fetched by /repos/{owner}/{repo}/git/tags/{tag_sha}
+	// Because lightweight tags do not have their own SHA, they only reference a commit
+	// Docs https://docs.github.com/rest/git/tags#get-a-tag
+	//
+	// So in order to check if a tag exists by name (both lightweights and annotated tags), GET /repos/{owner}/{repo}/git/ref/{ref} is used
+	// Docs https://docs.github.com/rest/git/refs#get-a-reference
+	_, _, err := c.client.Git.GetRef(
+		ctx,
+		repo.OwnerSlug,
+		repo.RepositorySlug,
+		fmt.Sprintf("tags/%s", tagName),
+	)
+	if err != nil {
+		return svcmodel.GitTag{}, util.ToGithubError(err)
+	}
+
+	return model.ToSvcGitTag(tagName), nil
+}
+
+func (c *Client) getReleaseByTag(ctx context.Context, repo svcmodel.GithubRepository, tagName string) (svcmodel.GithubRelease, error) {
+	gr, _, err := c.client.Repositories.GetReleaseByTag(
+		ctx,
+		repo.OwnerSlug,
+		repo.RepositorySlug,
+		tagName,
+	)
+	if err != nil {
+		return svcmodel.GithubRelease{}, util.ToGithubError(err)
+	}
+
+	r, err := model.ToSvcGithubRelease(gr)
+	if err != nil {
+		return svcmodel.GithubRelease{}, githuberrors.NewToSvcModelError().Wrap(err)
+	}
+
+	return r, nil
+}
+
+func (c *Client) generateReleaseNotes(ctx context.Context, repo svcmodel.GithubRepository, input svcmodel.CreateReleaseDraftInput) (model.GeneratedNotes, error) {
+	// When creating a GitHub release (or generating release notes), the tag name is required
+	// If tag does not exist yet, the release notes will be generated from the target commitish (can be a branch or a commit SHA)
+	// If target commitish is not provided, the default branch will be used
+	// Docs https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#generate-release-notes-content-for-a-release
+	n, _, err := c.client.Repositories.GenerateReleaseNotes(ctx, repo.OwnerSlug, repo.RepositorySlug, &github.GenerateNotesOptions{
+		TagName:         input.TagName,
+		TargetCommitish: input.TargetCommitish,
+		PreviousTagName: input.PreviousTagName,
+	})
+	if err != nil {
+		return model.GeneratedNotes{}, util.ToGithubError(err) // TODO handle more specific errors such as invalid target commitish etc
+	}
+
+	return model.GeneratedNotes{
+		ReleaseName:  n.Name,
+		ReleaseNotes: n.Body,
+	}, nil
 }

--- a/github/mock/mock.go
+++ b/github/mock/mock.go
@@ -12,11 +12,16 @@ type Client struct {
 	mock.Mock
 }
 
-func (m *Client) SetToken(token string) {
+func (m *Client) RefreshClientWithToken(token string) {
 	m.Called(token)
 }
 
 func (m *Client) ListTagsForRepository(ctx context.Context, repo svcmodel.GithubRepository) ([]svcmodel.GitTag, error) {
 	args := m.Called(ctx, repo)
 	return args.Get(0).([]svcmodel.GitTag), args.Error(1)
+}
+
+func (m *Client) CreateReleaseDraft(ctx context.Context, repo svcmodel.GithubRepository, input svcmodel.CreateReleaseDraftInput) (svcmodel.ReleaseDraft, error) {
+	args := m.Called(ctx, repo, input)
+	return args.Get(0).(svcmodel.ReleaseDraft), args.Error(1)
 }

--- a/github/model/model.go
+++ b/github/model/model.go
@@ -16,7 +16,9 @@ type GeneratedNotes struct {
 func ToSvcGitTags(tags []*github.RepositoryTag) []svcmodel.GitTag {
 	t := make([]svcmodel.GitTag, 0, len(tags))
 	for _, tag := range tags {
-		t = append(t, ToSvcGitTag(*tag.Name))
+		if tag.Name != nil {
+			t = append(t, ToSvcGitTag(*tag.Name))
+		}
 	}
 
 	return t

--- a/github/model/model.go
+++ b/github/model/model.go
@@ -1,16 +1,63 @@
 package model
 
 import (
+	"net/url"
+
 	svcmodel "release-manager/service/model"
 
 	"github.com/google/go-github/v60/github"
 )
 
+type GeneratedNotes struct {
+	ReleaseName  string
+	ReleaseNotes string
+}
+
 func ToSvcGitTags(tags []*github.RepositoryTag) []svcmodel.GitTag {
 	t := make([]svcmodel.GitTag, 0, len(tags))
 	for _, tag := range tags {
-		t = append(t, svcmodel.GitTag{Name: *tag.Name})
+		t = append(t, ToSvcGitTag(*tag.Name))
 	}
 
 	return t
+}
+
+func ToSvcGitTag(name string) svcmodel.GitTag {
+	return svcmodel.GitTag{Name: name}
+}
+
+func ToSvcGithubRelease(r *github.RepositoryRelease) (svcmodel.GithubRelease, error) {
+	var svcRelease svcmodel.GithubRelease
+
+	if r.HTMLURL != nil {
+		u, err := url.Parse(*r.HTMLURL)
+		if err != nil {
+			return svcmodel.GithubRelease{}, err
+		}
+
+		svcRelease.ReleasePageURL = *u
+	}
+
+	if r.Name != nil {
+		svcRelease.Name = *r.Name
+	}
+
+	if r.Body != nil {
+		svcRelease.ReleaseNotes = *r.Body
+	}
+
+	return svcRelease, nil
+}
+
+func ToSvcGitTagInput(tagName string, targetCommitish *string) svcmodel.GitTagInput {
+	if targetCommitish == nil {
+		return svcmodel.GitTagInput{
+			TagName: tagName,
+		}
+	}
+
+	return svcmodel.GitTagInput{
+		TagName:         tagName,
+		TargetCommitish: *targetCommitish,
+	}
 }

--- a/pkg/githuberrors/githuberrors.go
+++ b/pkg/githuberrors/githuberrors.go
@@ -6,10 +6,11 @@ import (
 )
 
 const (
-	errCodeUnauthorized = "ERR_GITHUB_UNAUTHORIZED"
-	errCodeForbidden    = "ERR_GITHUB_FORBIDDEN"
-	errCodeNotFound     = "ERR_GITHUB_NOT_FOUND"
-	errCodeUnknown      = "ERR_GITHUB_UNKNOWN"
+	errCodeUnauthorized        = "ERR_GITHUB_UNAUTHORIZED"
+	errCodeForbidden           = "ERR_GITHUB_FORBIDDEN"
+	errCodeNotFound            = "ERR_GITHUB_NOT_FOUND"
+	errCodeCannotMapToSvcModel = "ERR_GITHUB_CANNOT_MAP_TO_SVC_MODEL"
+	errCodeUnknown             = "ERR_GITHUB_UNKNOWN"
 )
 
 type GithubError struct {
@@ -49,6 +50,12 @@ func NewNotFoundError() *GithubError {
 func NewUnknownError() *GithubError {
 	return &GithubError{
 		Code: errCodeUnknown,
+	}
+}
+
+func NewToSvcModelError() *GithubError {
+	return &GithubError{
+		Code: errCodeCannotMapToSvcModel,
 	}
 }
 

--- a/service/model/project.go
+++ b/service/model/project.go
@@ -197,7 +197,3 @@ func toGithubRepository(rawURL string) (GithubRepository, error) {
 		RepositorySlug: slugs[1],
 	}, nil
 }
-
-type GitTag struct {
-	Name string
-}

--- a/service/model/release.go
+++ b/service/model/release.go
@@ -1,0 +1,109 @@
+package model
+
+import (
+	"errors"
+	"net/url"
+)
+
+var (
+	errTagNameRequired               = errors.New("tag name is required")
+	errReleaseNameRequired           = errors.New("release name is required")
+	errReleaseSourceCodeLinkRequired = errors.New("release must be linked to a source code")
+	errReleaseSourceCodeLinkConflict = errors.New("release can be linked to either a new git tag or an existing git tag, not both")
+	errGithubReleaseNameRequired     = errors.New("github release name is required")
+	errGithubReleasePageURLRequired  = errors.New("github release page URL is required")
+)
+
+type CreateReleaseDraftInput struct {
+	TagName string
+	// The commitish value, which can be a branch name or a commit SHA, specifies the base from which a Git tag is created (if it does not exist yet)
+	// If not provided, the default branch of the repository is used
+	TargetCommitish *string
+	PreviousTagName *string
+}
+
+func (c CreateReleaseDraftInput) Validate() error {
+	if c.TagName == "" {
+		return errTagNameRequired
+	}
+
+	return nil
+}
+
+type GitTag struct {
+	Name string
+}
+
+type GitTagInput struct {
+	TagName         string
+	TargetCommitish string
+}
+
+type GithubRelease struct {
+	Name           string
+	ReleaseNotes   string
+	ReleasePageURL url.URL // Link to the release page on GitHub
+}
+
+func (g GithubRelease) Validate() error {
+	if g.Name == "" {
+		return errGithubReleaseNameRequired
+	}
+
+	if g.ReleasePageURL == (url.URL{}) {
+		return errGithubReleasePageURLRequired
+	}
+
+	return nil
+}
+
+type ReleaseDraft struct {
+	Name           string
+	ReleaseNotes   string
+	SourceCodeLink struct { // links the release with the source code, either by a new git tag or an existing git tag
+		NewGitTag      *GitTagInput
+		ExistingGitTag *GitTag
+	}
+	GithubRelease *GithubRelease
+}
+
+func (r *ReleaseDraft) Validate() error {
+	if r.Name == "" {
+		return errReleaseNameRequired
+	}
+
+	if r.SourceCodeLink.NewGitTag == nil && r.SourceCodeLink.ExistingGitTag == nil {
+		return errReleaseSourceCodeLinkRequired
+	}
+
+	if r.SourceCodeLink.NewGitTag != nil && r.SourceCodeLink.ExistingGitTag != nil {
+		return errReleaseSourceCodeLinkConflict
+	}
+
+	if r.GithubRelease != nil {
+		if err := r.GithubRelease.Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func NewDraftRelease(name, notes string) ReleaseDraft {
+	return ReleaseDraft{
+		Name:         name,
+		ReleaseNotes: notes,
+	}
+}
+
+func (r *ReleaseDraft) LinkSourceCodeByNewTag(g GitTagInput) {
+	r.SourceCodeLink.NewGitTag = &g
+}
+
+func (r *ReleaseDraft) LinkSourceCodeByExistingTag(t GitTag) {
+	r.SourceCodeLink.ExistingGitTag = &t
+}
+
+func (r *ReleaseDraft) AddGithubRelease(gr GithubRelease) {
+	r.GithubRelease = &gr
+}

--- a/service/project.go
+++ b/service/project.go
@@ -244,7 +244,7 @@ func (s *ProjectService) ListGithubRepositoryTags(ctx context.Context, projectID
 		return nil, apierrors.NewGithubRepositoryNotConfiguredForProjectError()
 	}
 
-	s.githubRepositoryManager.SetToken(github.Token)
+	s.githubRepositoryManager.RefreshClientWithToken(github.Token)
 
 	t, err := s.githubRepositoryManager.ListTagsForRepository(ctx, project.GithubRepository)
 	if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -62,7 +62,8 @@ type projectInvitationSender interface {
 
 type githubRepositoryManager interface {
 	ListTagsForRepository(ctx context.Context, repo model.GithubRepository) ([]model.GitTag, error)
-	SetToken(token string)
+	RefreshClientWithToken(token string)
+	CreateReleaseDraft(ctx context.Context, repo model.GithubRepository, input model.CreateReleaseDraftInput) (model.ReleaseDraft, error)
 }
 
 type emailSender interface {


### PR DESCRIPTION
This PR introduces functionality for drafting a release. In the first step of release creation, the user provides a Git tag, and the release is drafted. The flow is also described[ in Notion](https://www.notion.so/Release-creation-flow-67b183b3010f4695b9c54602fc8b95f8).

> [!WARNING] 
> ReleaseDraft will not be saved to the database; it will only be returned as a response (so client can "prefill" release creation form with drafted release). Therefore, I am not completely convinced about the wording. Feel free to suggest a different name; I will sleep on it and think about it more tomorrow.

<img width="687" alt="Snímek obrazovky 2024-05-02 v 21 52 23" src="https://github.com/jan-zabloudil/release-manager/assets/81581922/16b5ede3-a42a-43cf-9776-a5431df3ff46">

Drafted release:
- user sees if provided git tag already exists or a new tag will be created
- user sees if provided git tag is associated with a GitHub release (in the case of an existing tag).
- release name and notes are generated

<img width="632" alt="Snímek obrazovky 2024-05-02 v 21 54 46" src="https://github.com/jan-zabloudil/release-manager/assets/81581922/388eb06f-aa92-456d-ac29-ab5bb311510f">

_* Wireframes has older naming such as changelog, instead of release notes etc._

--- 

To keep the PR smaller, I only added the necessary functionality to the GitHub client and service models. The rest will be implemented in upcoming PRs _(service model tests will be added in this PR once PR is approved)_.