### PR TITLE
feat: create project member when invitation is accepted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,15 @@ require (
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.19.0
+	github.com/google/go-github/v60 v60.0.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/nedpals/postgrest-go v0.1.3
 	github.com/nedpals/supabase-go v0.4.0
+	github.com/resend/resend-go/v2 v2.6.0
 	github.com/sethvargo/go-envconfig v1.0.1
 	github.com/stretchr/testify v1.9.0
+	go.strv.io/background v0.1.0
 	go.strv.io/net v0.7.0
 	go.strv.io/time v0.2.0
 )
@@ -20,15 +23,12 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
-	github.com/google/go-github/v60 v60.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/kamilsk/retry/v5 v5.0.0-rc8 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/resend/resend-go/v2 v2.6.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.strv.io/background v0.1.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
@@ -38,4 +38,4 @@ require (
 
 replace github.com/nedpals/supabase-go => github.com/jan-zabloudil/supabase-go v0.0.0-20240229160758-916b4e4b1b63
 
-replace github.com/nedpals/postgrest-go => github.com/jan-zabloudil/postgrest-go v0.1.4-0.20240313092915-4ca6efcd60a7
+replace github.com/nedpals/postgrest-go => github.com/jan-zabloudil/postgrest-go v0.1.4-0.20240504155537-5b7dad2b7e87

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/jan-zabloudil/postgrest-go v0.1.4-0.20240313092915-4ca6efcd60a7 h1:DBeTf8aphChb1A87/7ilCc55Kx15T7yfKzT0UBTOfwQ=
-github.com/jan-zabloudil/postgrest-go v0.1.4-0.20240313092915-4ca6efcd60a7/go.mod h1:RGinB2OXsnGLcZMu5avS0U+b9npyZmk+ecK74UDi/xY=
+github.com/jan-zabloudil/postgrest-go v0.1.4-0.20240504155537-5b7dad2b7e87 h1:0fyBQ0H//wldrJ328bOetR5Tk+qpRWuuJlPK5YeoKU8=
+github.com/jan-zabloudil/postgrest-go v0.1.4-0.20240504155537-5b7dad2b7e87/go.mod h1:RGinB2OXsnGLcZMu5avS0U+b9npyZmk+ecK74UDi/xY=
 github.com/jan-zabloudil/supabase-go v0.0.0-20240229160758-916b4e4b1b63 h1:uI0NCjMzb3/XkxOuEhkbodL4f7+2ldcQpzquoYbCfgk=
 github.com/jan-zabloudil/supabase-go v0.0.0-20240229160758-916b4e4b1b63/go.mod h1:rscvF0tYsD6gJYKMYZy8e6YWspVIaGnBb13PlU6HFcU=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/repository/mock/project.go
+++ b/repository/mock/project.go
@@ -104,6 +104,11 @@ func (m *ProjectRepository) DeleteInvitation(ctx context.Context, id uuid.UUID) 
 	return args.Error(0)
 }
 
+func (m *ProjectRepository) CreateMember(ctx context.Context, member svcmodel.ProjectMember) error {
+	args := m.Called(ctx, member)
+	return args.Error(0)
+}
+
 func (m *ProjectRepository) ReadMembersForProject(ctx context.Context, projectID uuid.UUID) ([]svcmodel.ProjectMember, error) {
 	args := m.Called(ctx, projectID)
 	return args.Get(0).([]svcmodel.ProjectMember), args.Error(1)

--- a/repository/mock/user.go
+++ b/repository/mock/user.go
@@ -18,6 +18,11 @@ func (m *UserRepository) Read(ctx context.Context, userID uuid.UUID) (svcmodel.U
 	return args.Get(0).(svcmodel.User), args.Error(1)
 }
 
+func (m *UserRepository) ReadByEmail(ctx context.Context, email string) (svcmodel.User, error) {
+	args := m.Called(ctx, email)
+	return args.Get(0).(svcmodel.User), args.Error(1)
+}
+
 func (m *UserRepository) ReadAll(ctx context.Context) ([]svcmodel.User, error) {
 	args := m.Called(ctx)
 	return args.Get(0).([]svcmodel.User), args.Error(1)

--- a/repository/model/project_member.go
+++ b/repository/model/project_member.go
@@ -8,12 +8,14 @@ import (
 	"github.com/google/uuid"
 )
 
+// CreateProjectMemberInput is the input for creating a project member and deleting an invitation
 type CreateProjectMemberInput struct {
-	UserID      uuid.UUID `json:"user_id"`
-	ProjectID   uuid.UUID `json:"project_id"`
-	ProjectRole string    `json:"project_role"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	UserID      uuid.UUID `json:"p_user_id"`
+	ProjectID   uuid.UUID `json:"p_project_id"`
+	Email       string    `json:"p_email"`
+	ProjectRole string    `json:"p_project_role"`
+	CreatedAt   time.Time `json:"p_created_at"`
+	UpdatedAt   time.Time `json:"p_updated_at"`
 }
 
 type ProjectMember struct {
@@ -22,6 +24,17 @@ type ProjectMember struct {
 	ProjectRole string    `json:"project_role"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+func ToCreateProjectMemberInput(m svcmodel.ProjectMember) CreateProjectMemberInput {
+	return CreateProjectMemberInput{
+		UserID:      m.User.ID,
+		ProjectID:   m.ProjectID,
+		Email:       m.User.Email,
+		ProjectRole: string(m.ProjectRole),
+		CreatedAt:   m.CreatedAt,
+		UpdatedAt:   m.UpdatedAt,
+	}
 }
 
 func ToSvcProjectMember(p ProjectMember) svcmodel.ProjectMember {

--- a/repository/user.go
+++ b/repository/user.go
@@ -39,6 +39,20 @@ func (r *UserRepository) Read(ctx context.Context, userID uuid.UUID) (svcmodel.U
 	return model.ToSvcUser(resp), nil
 }
 
+func (r *UserRepository) ReadByEmail(ctx context.Context, email string) (svcmodel.User, error) {
+	var resp model.User
+	err := r.client.
+		DB.From(userDBEntity).
+		Select("*").Single().
+		Eq("email", email).
+		ExecuteWithContext(ctx, &resp)
+	if err != nil {
+		return svcmodel.User{}, util.ToDBError(err)
+	}
+
+	return model.ToSvcUser(resp), nil
+}
+
 func (r *UserRepository) ReadAll(ctx context.Context) ([]svcmodel.User, error) {
 	var resp []model.User
 	err := r.client.

--- a/service/mock/user.go
+++ b/service/mock/user.go
@@ -1,0 +1,18 @@
+package mock
+
+import (
+	"context"
+
+	"release-manager/service/model"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type UserService struct {
+	mock.Mock
+}
+
+func (m *UserService) GetByEmail(ctx context.Context, email string) (model.User, error) {
+	args := m.Called(ctx, email)
+	return args.Get(0).(model.User), args.Error(1)
+}

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -70,9 +70,10 @@ func TestProjectService_CreateProject(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 
@@ -120,9 +121,10 @@ func TestProjectService_GetProject(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 
@@ -173,9 +175,10 @@ func TestProjectService_DeleteProject(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 
@@ -270,9 +273,10 @@ func TestProjectService_UpdateProject(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 
@@ -359,9 +363,10 @@ func TestProjectService_CreateEnvironment(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 
@@ -423,9 +428,10 @@ func TestProjectService_GetEnvironment(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 
@@ -513,9 +519,10 @@ func TestProjectService_UpdateEnvironment(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 
@@ -564,9 +571,10 @@ func TestProjectService_GetEnvironments(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 
@@ -632,9 +640,10 @@ func TestProjectService_DeleteEnvironment(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 
@@ -693,9 +702,10 @@ func TestProjectService_validateEnvironmentNameUnique(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 
@@ -793,9 +803,10 @@ func TestProjectService_Invite(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, emailSvc, projectRepo)
 
@@ -849,9 +860,10 @@ func TestProjectService_GetInvitations(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 
@@ -909,9 +921,10 @@ func TestProjectService_CancelInvitation(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 
@@ -932,26 +945,41 @@ func TestProjectService_CancelInvitation(t *testing.T) {
 func TestProjectService_AcceptInvitation(t *testing.T) {
 	testCases := []struct {
 		name      string
-		mockSetup func(repository *repo.ProjectRepository)
+		mockSetup func(user *svc.UserService, repository *repo.ProjectRepository)
 		wantErr   bool
 	}{
 		{
 			name: "Unknown invitation",
-			mockSetup: func(projectRepo *repo.ProjectRepository) {
+			mockSetup: func(user *svc.UserService, projectRepo *repo.ProjectRepository) {
 				projectRepo.On("ReadInvitationByTokenHashAndStatus", mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectInvitation{}, dberrors.NewNotFoundError())
 			},
 			wantErr: true,
 		},
 		{
-			name: "Success",
-			mockSetup: func(projectRepo *repo.ProjectRepository) {
+			name: "Success - invitation is accepted",
+			mockSetup: func(user *svc.UserService, projectRepo *repo.ProjectRepository) {
 				projectRepo.On("ReadInvitationByTokenHashAndStatus", mock.Anything, mock.Anything, mock.Anything).Return(
 					model.ProjectInvitation{
 						Email: "test@test.tt", ProjectRole: model.ProjectRoleEditor, Status: model.InvitationStatusPending, ProjectID: uuid.New(),
 					},
 					nil,
 				)
+				user.On("GetByEmail", mock.Anything, mock.Anything).Return(model.User{}, apierrors.NewUserNotFoundError())
 				projectRepo.On("UpdateInvitation", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "Success - project member is created",
+			mockSetup: func(user *svc.UserService, projectRepo *repo.ProjectRepository) {
+				projectRepo.On("ReadInvitationByTokenHashAndStatus", mock.Anything, mock.Anything, mock.Anything).Return(
+					model.ProjectInvitation{
+						Email: "test@test.tt", ProjectRole: model.ProjectRoleEditor, Status: model.InvitationStatusPending, ProjectID: uuid.New(),
+					},
+					nil,
+				)
+				user.On("GetByEmail", mock.Anything, mock.Anything).Return(model.User{}, nil)
+				projectRepo.On("CreateMember", mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -962,11 +990,12 @@ func TestProjectService_AcceptInvitation(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
-			tc.mockSetup(projectRepo)
+			tc.mockSetup(userSvc, projectRepo)
 
 			tkn, err := cryptox.NewToken()
 			if err != nil {
@@ -981,6 +1010,7 @@ func TestProjectService_AcceptInvitation(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
+			userSvc.AssertExpectations(t)
 			projectRepo.AssertExpectations(t)
 		})
 	}
@@ -1019,9 +1049,10 @@ func TestProjectService_RejectInvitation(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(projectRepo)
 
@@ -1076,9 +1107,10 @@ func TestProjectService_ListMembers(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 
@@ -1139,9 +1171,10 @@ func TestProjectService_DeleteMember(t *testing.T) {
 			projectRepo := new(repo.ProjectRepository)
 			githubClient := new(github.Client)
 			emailSvc := new(svc.EmailService)
+			userSvc := new(svc.UserService)
 			settingsSvc := new(svc.SettingsService)
 			authSvc := new(svc.AuthService)
-			service := NewProjectService(authSvc, settingsSvc, githubClient, emailSvc, projectRepo)
+			service := NewProjectService(authSvc, settingsSvc, userSvc, githubClient, emailSvc, projectRepo)
 
 			tc.mockSetup(authSvc, projectRepo)
 

--- a/service/service.go
+++ b/service/service.go
@@ -35,6 +35,7 @@ type projectRepository interface {
 	DeleteInvitation(ctx context.Context, invitationID uuid.UUID) error
 	UpdateInvitation(ctx context.Context, i model.ProjectInvitation) error
 
+	CreateMember(ctx context.Context, member model.ProjectMember) error
 	ReadMembersForProject(ctx context.Context, projectID uuid.UUID) ([]model.ProjectMember, error)
 	ReadMember(ctx context.Context, projectID, userID uuid.UUID) (model.ProjectMember, error)
 	DeleteMember(ctx context.Context, projectID, userID uuid.UUID) error
@@ -42,6 +43,7 @@ type projectRepository interface {
 
 type userRepository interface {
 	Read(ctx context.Context, id uuid.UUID) (model.User, error)
+	ReadByEmail(ctx context.Context, email string) (model.User, error)
 	ReadAll(ctx context.Context) ([]model.User, error)
 	Delete(ctx context.Context, id uuid.UUID) error
 }
@@ -58,6 +60,10 @@ type authGuard interface {
 
 type settingsGetter interface {
 	GetGithubSettings(ctx context.Context) (model.GithubSettings, error)
+}
+
+type userGetter interface {
+	GetByEmail(ctx context.Context, email string) (model.User, error)
 }
 
 type projectInvitationSender interface {
@@ -92,7 +98,7 @@ func NewService(
 	userSvc := NewUserService(authSvc, userRepo)
 	settingsSvc := NewSettingsService(authSvc, settingsRepo)
 	emailSvc := NewEmailService(emailSender)
-	projectSvc := NewProjectService(authSvc, settingsSvc, githubRepoManager, emailSvc, projectRepo)
+	projectSvc := NewProjectService(authSvc, settingsSvc, userSvc, githubRepoManager, emailSvc, projectRepo)
 
 	return &Service{
 		Auth:     authSvc,

--- a/service/user.go
+++ b/service/user.go
@@ -40,6 +40,20 @@ func (s *UserService) Get(ctx context.Context, id uuid.UUID, authUserID uuid.UUI
 	return u, nil
 }
 
+func (s *UserService) GetByEmail(ctx context.Context, email string) (model.User, error) {
+	u, err := s.repository.ReadByEmail(ctx, email)
+	if err != nil {
+		switch {
+		case dberrors.IsNotFoundError(err):
+			return model.User{}, apierrors.NewUserNotFoundError().Wrap(err)
+		default:
+			return model.User{}, err
+		}
+	}
+
+	return u, nil
+}
+
 func (s *UserService) Delete(ctx context.Context, id uuid.UUID, authUserID uuid.UUID) error {
 	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
 		return err

--- a/supabase/migrations/20240504161910_create_project_member_and_delete_invitation.sql
+++ b/supabase/migrations/20240504161910_create_project_member_and_delete_invitation.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE FUNCTION create_project_member_and_delete_invitation(
+    p_user_id UUID,
+    p_project_id UUID,
+    p_email TEXT,
+    p_project_role project_role,
+    p_created_at TIMESTAMP WITH TIME ZONE,
+    p_updated_at TIMESTAMP WITH TIME ZONE
+)
+    RETURNS void AS $$
+BEGIN
+        INSERT INTO public.project_members (user_id, project_id, project_role, created_at, updated_at)
+        VALUES (p_user_id, p_project_id, p_project_role, p_created_at, p_updated_at);
+
+        DELETE FROM public.project_invitations
+        WHERE project_id = p_project_id AND email = p_email;
+END;
+$$ LANGUAGE plpgsql;

--- a/supabase/migrations/20240504173609_check_accepted_invitations_for_registered_users.sql
+++ b/supabase/migrations/20240504173609_check_accepted_invitations_for_registered_users.sql
@@ -1,0 +1,24 @@
+-- trigger to prevent updating the status of a project invitation to 'accepted_awaiting_registration' if a user with the same email already exists
+-- this race condition can happen in ProjectService -> AcceptInvitation(), scenario:
+-- 1. service checks if user exists, user does not exist yet
+-- 2. service accepts invitation, status is updated to 'accepted_awaiting_registration'
+-- but the first and second steps are not executed in the same transaction, so a user with the same email can be created in the meantime
+-- very unlikely, but still possible
+
+CREATE OR REPLACE FUNCTION check_accepted_invitations_for_registered_users()
+    RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.status = 'accepted_awaiting_registration') AND EXISTS (
+        SELECT 1
+        FROM public.users AS u
+        WHERE u.email = NEW.email
+    ) THEN
+        RAISE EXCEPTION 'Cannot update status to accepted_awaiting_registration because a user with email % already exists', NEW.email;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER on_project_invitations_status_update
+    BEFORE UPDATE OF status ON public.project_invitations
+    FOR EACH ROW EXECUTE FUNCTION check_accepted_invitations_for_registered_users();


### PR DESCRIPTION
- Create a project member if a registered user accepts an invitation. 
- If a non-registered user accepts an invitation, only the invitation status is updated -> once the user signs up, they will be added to the project (implemented in #34)