### PR TITLE
 feat: add project member authorization functionality 

### DIFF
--- a/pkg/apierrors/apierrors.go
+++ b/pkg/apierrors/apierrors.go
@@ -8,6 +8,7 @@ import (
 var (
 	errCodeUnauthorizedInvalidToken                = "ERR_UNAUTHORIZED_ACCESS_INVALID_TOKEN"
 	errCodeForbiddenInsufficientUserRole           = "ERR_FORBIDDEN_ACCESS_INSUFFICIENT_USER_ROLE"
+	errCodeForbiddenInsufficientProjectRole        = "ERR_FORBIDDEN_ACCESS_INSUFFICIENT_PROJECT_ROLE"
 	errCodeUserNotFound                            = "ERR_USER_NOT_FOUND"
 	errCodeProjectNotFound                         = "ERR_PROJECT_NOT_FOUND"
 	errCodeEnvironmentNotFound                     = "ERR_ENVIRONMENT_NOT_FOUND"
@@ -112,6 +113,13 @@ func NewForbiddenInsufficientUserRoleError() *APIError {
 	}
 }
 
+func NewForbiddenInsufficientProjectRoleError() *APIError {
+	return &APIError{
+		Code:    errCodeForbiddenInsufficientUserRole,
+		Message: "Forbidden access, insufficient project role.",
+	}
+}
+
 func NewProjectInvitationUnprocessableError() *APIError {
 	return &APIError{
 		Code:    errCodeProjectInvitationUnprocessable,
@@ -209,7 +217,8 @@ func IsUnauthorizedError(err error) bool {
 
 func IsForbiddenError(err error) bool {
 	return IsErrorWithCode(err, errCodeForbiddenInsufficientUserRole) ||
-		IsErrorWithCode(err, errCodeGithubIntegrationForbidden)
+		IsErrorWithCode(err, errCodeGithubIntegrationForbidden) ||
+		IsErrorWithCode(err, errCodeForbiddenInsufficientProjectRole)
 }
 
 func IsConflictError(err error) bool {

--- a/service/mock/auth.go
+++ b/service/mock/auth.go
@@ -18,12 +18,22 @@ func (m *AuthService) Authenticate(ctx context.Context, token string) (uuid.UUID
 	return args.Get(0).(uuid.UUID), args.Error(1)
 }
 
-func (m *AuthService) AuthorizeAdminRole(ctx context.Context, userID uuid.UUID) error {
+func (m *AuthService) AuthorizeUserRoleAdmin(ctx context.Context, userID uuid.UUID) error {
 	args := m.Called(ctx, userID)
 	return args.Error(0)
 }
 
-func (m *AuthService) AuthorizeRole(ctx context.Context, userID uuid.UUID, role model.UserRole) error {
+func (m *AuthService) AuthorizeUserRole(ctx context.Context, userID uuid.UUID, role model.UserRole) error {
 	args := m.Called(ctx, userID, role)
+	return args.Error(0)
+}
+
+func (m *AuthService) AuthorizeProjectRoleViewer(ctx context.Context, projectID, userID uuid.UUID) error {
+	args := m.Called(ctx, projectID, userID)
+	return args.Error(0)
+}
+
+func (m *AuthService) AuthorizeProjectRoleEditor(ctx context.Context, projectID, userID uuid.UUID) error {
+	args := m.Called(ctx, projectID, userID)
 	return args.Error(0)
 }

--- a/service/model/user.go
+++ b/service/model/user.go
@@ -35,6 +35,10 @@ func (s User) HasAtLeastRole(role UserRole) bool {
 	return s.Role.IsRoleAtLeast(role)
 }
 
+func (s User) IsAdmin() bool {
+	return s.Role == UserRoleAdmin
+}
+
 func (r UserRole) IsRoleAtLeast(role UserRole) bool {
 	return userRolePriority[r] <= userRolePriority[role]
 }

--- a/service/model/user_test.go
+++ b/service/model/user_test.go
@@ -52,3 +52,25 @@ func TestUserRole_IsRoleAtLeast(t *testing.T) {
 		})
 	}
 }
+
+func TestUser_IsAdmin(t *testing.T) {
+	testCases := []struct {
+		name     string
+		userRole UserRole
+		expected bool
+	}{
+		{"Admin user", UserRoleAdmin, true},
+		{"Non-admin user", UserRoleUser, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			user := User{
+				ID:   uuid.New(),
+				Role: tc.userRole,
+			}
+
+			assert.Equal(t, tc.expected, user.IsAdmin())
+		})
+	}
+}

--- a/service/project.go
+++ b/service/project.go
@@ -41,7 +41,7 @@ func NewProjectService(
 }
 
 func (s *ProjectService) CreateProject(ctx context.Context, c model.CreateProjectInput, authUserID uuid.UUID) (model.Project, error) {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return model.Project{}, err
 	}
 
@@ -91,7 +91,7 @@ func (s *ProjectService) ListProjects(ctx context.Context, authUserID uuid.UUID)
 }
 
 func (s *ProjectService) DeleteProject(ctx context.Context, projectID uuid.UUID, authUserID uuid.UUID) error {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return err
 	}
 
@@ -123,7 +123,7 @@ func (s *ProjectService) UpdateProject(ctx context.Context, u model.UpdateProjec
 }
 
 func (s *ProjectService) CreateEnvironment(ctx context.Context, c model.CreateEnvironmentInput, authUserID uuid.UUID) (model.Environment, error) {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return model.Environment{}, err
 	}
 
@@ -220,7 +220,7 @@ func (s *ProjectService) ListEnvironments(ctx context.Context, projectID, authUs
 }
 
 func (s *ProjectService) DeleteEnvironment(ctx context.Context, projectID, envID uuid.UUID, authUserID uuid.UUID) error {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return err
 	}
 
@@ -278,7 +278,7 @@ func (s *ProjectService) ListGithubRepositoryTags(ctx context.Context, projectID
 }
 
 func (s *ProjectService) Invite(ctx context.Context, c model.CreateProjectInvitationInput, authUserID uuid.UUID) (model.ProjectInvitation, error) {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return model.ProjectInvitation{}, err
 	}
 
@@ -321,7 +321,7 @@ func (s *ProjectService) Invite(ctx context.Context, c model.CreateProjectInvita
 }
 
 func (s *ProjectService) ListInvitations(ctx context.Context, projectID, authUserID uuid.UUID) ([]model.ProjectInvitation, error) {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return nil, err
 	}
 
@@ -337,7 +337,7 @@ func (s *ProjectService) ListInvitations(ctx context.Context, projectID, authUse
 }
 
 func (s *ProjectService) CancelInvitation(ctx context.Context, projectID, invitationID, authUserID uuid.UUID) error {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return err
 	}
 

--- a/service/project.go
+++ b/service/project.go
@@ -400,7 +400,7 @@ func (s *ProjectService) RejectInvitation(ctx context.Context, tkn cryptox.Token
 }
 
 func (s *ProjectService) ListMembers(ctx context.Context, projectID, authUserID uuid.UUID) ([]model.ProjectMember, error) {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return nil, err
 	}
 
@@ -416,7 +416,7 @@ func (s *ProjectService) ListMembers(ctx context.Context, projectID, authUserID 
 }
 
 func (s *ProjectService) DeleteMember(ctx context.Context, projectID, userID, authUserID uuid.UUID) error {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return err
 	}
 

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -33,7 +33,7 @@ func TestProjectService_CreateProject(t *testing.T) {
 				ReleaseNotificationConfig: model.ReleaseNotificationConfig{},
 			},
 			mockSetup: func(auth *svc.AuthService, user *svc.UserService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				user.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(model.User{}, nil)
 				projectRepo.On("CreateProject", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
@@ -47,7 +47,7 @@ func TestProjectService_CreateProject(t *testing.T) {
 				ReleaseNotificationConfig: model.ReleaseNotificationConfig{},
 			},
 			mockSetup: func(auth *svc.AuthService, user *svc.UserService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: true,
 		},
@@ -60,7 +60,7 @@ func TestProjectService_CreateProject(t *testing.T) {
 				GithubRepositoryRawURL:    "https://github.com/owner",
 			},
 			mockSetup: func(auth *svc.AuthService, user *svc.UserService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: true,
 		},
@@ -155,7 +155,7 @@ func TestProjectService_DeleteProject(t *testing.T) {
 			name:      "Existing project",
 			projectID: uuid.New(),
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("DeleteProject", mock.Anything, mock.Anything).Return(nil)
 			},
@@ -165,7 +165,7 @@ func TestProjectService_DeleteProject(t *testing.T) {
 			name:      "Non-existing project",
 			projectID: uuid.Nil,
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything).Return(model.Project{}, errors.New("project not found"))
 			},
 			wantErr: true,
@@ -311,7 +311,7 @@ func TestProjectService_CreateEnvironment(t *testing.T) {
 				ServiceRawURL: "http://example.com",
 			},
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("ReadEnvironmentByNameForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Environment{}, dberrors.NewNotFoundError())
 				projectRepo.On("CreateEnvironment", mock.Anything, mock.Anything).Return(nil)
@@ -326,7 +326,7 @@ func TestProjectService_CreateEnvironment(t *testing.T) {
 				ServiceRawURL: "http://example.com",
 			},
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("ReadEnvironmentByNameForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Environment{}, nil)
 			},
@@ -340,7 +340,7 @@ func TestProjectService_CreateEnvironment(t *testing.T) {
 				ServiceRawURL: "example",
 			},
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
 			},
 			wantErr: true,
@@ -353,7 +353,7 @@ func TestProjectService_CreateEnvironment(t *testing.T) {
 				ServiceRawURL: "example",
 			},
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
 			},
 			wantErr: true,
@@ -607,7 +607,7 @@ func TestProjectService_DeleteEnvironment(t *testing.T) {
 			projectID: uuid.New(),
 			envID:     uuid.New(),
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("ReadEnvironment", mock.Anything, mock.Anything, mock.Anything).Return(model.Environment{}, nil)
 				projectRepo.On("DeleteEnvironment", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -619,7 +619,7 @@ func TestProjectService_DeleteEnvironment(t *testing.T) {
 			projectID: uuid.New(),
 			envID:     uuid.New(),
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, errors.New("project not found"))
 			},
 			wantErr: true,
@@ -629,7 +629,7 @@ func TestProjectService_DeleteEnvironment(t *testing.T) {
 			projectID: uuid.New(),
 			envID:     uuid.New(),
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("ReadEnvironment", mock.Anything, mock.Anything, mock.Anything).Return(model.Environment{}, errors.New("env not found"))
 			},
@@ -737,7 +737,7 @@ func TestProjectService_Invite(t *testing.T) {
 			name:     "Unknown project",
 			creation: model.CreateProjectInvitationInput{},
 			mockSetup: func(auth *svc.AuthService, email *svc.EmailService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, apierrors.NewProjectNotFoundError())
 			},
 			wantErr: true,
@@ -750,7 +750,7 @@ func TestProjectService_Invite(t *testing.T) {
 				ProjectID:   uuid.New(),
 			},
 			mockSetup: func(auth *svc.AuthService, email *svc.EmailService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, dberrors.NewNotFoundError())
 			},
 			wantErr: true,
@@ -763,7 +763,7 @@ func TestProjectService_Invite(t *testing.T) {
 				ProjectID:   uuid.New(),
 			},
 			mockSetup: func(auth *svc.AuthService, email *svc.EmailService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
 			},
 			wantErr: true,
@@ -776,7 +776,7 @@ func TestProjectService_Invite(t *testing.T) {
 				ProjectID:   uuid.New(),
 			},
 			mockSetup: func(auth *svc.AuthService, email *svc.EmailService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("ReadInvitationByEmailForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectInvitation{}, nil)
 			},
@@ -790,7 +790,7 @@ func TestProjectService_Invite(t *testing.T) {
 				ProjectID:   uuid.New(),
 			},
 			mockSetup: func(auth *svc.AuthService, email *svc.EmailService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("ReadInvitationByEmailForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectInvitation{}, dberrors.NewNotFoundError())
 				projectRepo.On("CreateInvitation", mock.Anything, mock.Anything).Return(nil)
@@ -836,7 +836,7 @@ func TestProjectService_GetInvitations(t *testing.T) {
 		{
 			name: "Unknown project",
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, dberrors.NewNotFoundError())
 			},
 			wantErr: true,
@@ -844,7 +844,7 @@ func TestProjectService_GetInvitations(t *testing.T) {
 		{
 			name: "Success",
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("ReadAllInvitationsForProject", mock.Anything, mock.Anything).Return(
 					[]model.ProjectInvitation{
@@ -892,7 +892,7 @@ func TestProjectService_CancelInvitation(t *testing.T) {
 		{
 			name: "Unknown project",
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, dberrors.NewNotFoundError())
 			},
 			wantErr: true,
@@ -900,7 +900,7 @@ func TestProjectService_CancelInvitation(t *testing.T) {
 		{
 			name: "Unknown invitation",
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("ReadInvitation", mock.Anything, mock.Anything).Return(model.ProjectInvitation{}, dberrors.NewNotFoundError())
 			},
@@ -909,7 +909,7 @@ func TestProjectService_CancelInvitation(t *testing.T) {
 		{
 			name: "Success",
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("ReadInvitation", mock.Anything, mock.Anything).Return(model.ProjectInvitation{}, nil)
 				projectRepo.On("DeleteInvitation", mock.Anything, mock.Anything).Return(nil)
@@ -1087,7 +1087,7 @@ func TestProjectService_ListMembers(t *testing.T) {
 			name:      "Non existing project",
 			projectID: uuid.New(),
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything).Return(model.Project{}, dberrors.NewNotFoundError())
 			},
 			wantErr: true,
@@ -1096,7 +1096,7 @@ func TestProjectService_ListMembers(t *testing.T) {
 			name:      "Success",
 			projectID: uuid.New(),
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("ReadMembersForProject", mock.Anything, mock.Anything).Return([]model.ProjectMember{}, nil)
 			},
@@ -1140,7 +1140,7 @@ func TestProjectService_DeleteMember(t *testing.T) {
 			name:      "Non existing project",
 			projectID: uuid.New(),
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything).Return(model.Project{}, dberrors.NewNotFoundError())
 			},
 			wantErr: true,
@@ -1149,7 +1149,7 @@ func TestProjectService_DeleteMember(t *testing.T) {
 			name:      "Non existing member",
 			projectID: uuid.New(),
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("ReadMember", mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectMember{}, dberrors.NewNotFoundError())
 			},
@@ -1159,7 +1159,7 @@ func TestProjectService_DeleteMember(t *testing.T) {
 			name:      "Success",
 			projectID: uuid.New(),
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {
-				auth.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("ReadMember", mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectMember{}, nil)
 				projectRepo.On("DeleteMember", mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/service/service.go
+++ b/service/service.go
@@ -54,8 +54,10 @@ type settingsRepository interface {
 }
 
 type authGuard interface {
-	AuthorizeAdminRole(ctx context.Context, userID uuid.UUID) error
-	AuthorizeRole(ctx context.Context, userID uuid.UUID, role model.UserRole) error
+	AuthorizeUserRoleAdmin(ctx context.Context, userID uuid.UUID) error
+	AuthorizeUserRole(ctx context.Context, userID uuid.UUID, model model.UserRole) error
+	AuthorizeProjectRoleEditor(ctx context.Context, projectID, userID uuid.UUID) error
+	AuthorizeProjectRoleViewer(ctx context.Context, projectID, userID uuid.UUID) error
 }
 
 type settingsGetter interface {
@@ -95,7 +97,7 @@ func NewService(
 	githubRepoManager githubRepositoryManager,
 	emailSender emailSender,
 ) *Service {
-	authSvc := NewAuthService(authRepo, userRepo)
+	authSvc := NewAuthService(authRepo, userRepo, projectRepo)
 	userSvc := NewUserService(authSvc, userRepo)
 	settingsSvc := NewSettingsService(authSvc, settingsRepo)
 	emailSvc := NewEmailService(emailSender)

--- a/service/settings.go
+++ b/service/settings.go
@@ -22,7 +22,7 @@ func NewSettingsService(guard authGuard, r settingsRepository) *SettingsService 
 }
 
 func (s *SettingsService) Get(ctx context.Context, authUserID uuid.UUID) (model.Settings, error) {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return model.Settings{}, err
 	}
 
@@ -30,7 +30,7 @@ func (s *SettingsService) Get(ctx context.Context, authUserID uuid.UUID) (model.
 }
 
 func (s *SettingsService) Update(ctx context.Context, u model.UpdateSettingsInput, authUserID uuid.UUID) (model.Settings, error) {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return model.Settings{}, err
 	}
 

--- a/service/settings_test.go
+++ b/service/settings_test.go
@@ -44,7 +44,7 @@ func TestSettingsService_Update(t *testing.T) {
 				},
 			},
 			mockSetup: func(authSvc *svc.AuthService, settingsRepo *repo.SettingsRepository) {
-				authSvc.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				authSvc.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				settingsRepo.On("Read", mock.Anything, mock.Anything).Return(settings, nil)
 				settingsRepo.On("Update", mock.Anything, mock.Anything).Return(nil)
 			},
@@ -61,7 +61,7 @@ func TestSettingsService_Update(t *testing.T) {
 				},
 			},
 			mockSetup: func(authSvc *svc.AuthService, settingsRepo *repo.SettingsRepository) {
-				authSvc.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				authSvc.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				settingsRepo.On("Read", mock.Anything, mock.Anything).Return(settings, nil)
 			},
 			expectErr: true,
@@ -73,7 +73,7 @@ func TestSettingsService_Update(t *testing.T) {
 				OrganizationName: &invalidName,
 			},
 			mockSetup: func(authSvc *svc.AuthService, settingsRepo *repo.SettingsRepository) {
-				authSvc.On("AuthorizeAdminRole", mock.Anything, mock.Anything).Return(nil)
+				authSvc.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				settingsRepo.On("Read", mock.Anything, mock.Anything).Return(settings, nil)
 			},
 			expectErr: true,

--- a/service/user.go
+++ b/service/user.go
@@ -23,7 +23,7 @@ func NewUserService(guard authGuard, repo userRepository) *UserService {
 }
 
 func (s *UserService) Get(ctx context.Context, id uuid.UUID, authUserID uuid.UUID) (model.User, error) {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return model.User{}, err
 	}
 
@@ -55,7 +55,7 @@ func (s *UserService) GetByEmail(ctx context.Context, email string) (model.User,
 }
 
 func (s *UserService) Delete(ctx context.Context, id uuid.UUID, authUserID uuid.UUID) error {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return err
 	}
 
@@ -68,7 +68,7 @@ func (s *UserService) Delete(ctx context.Context, id uuid.UUID, authUserID uuid.
 }
 
 func (s *UserService) ListAll(ctx context.Context, authUserID uuid.UUID) ([]model.User, error) {
-	if err := s.authGuard.AuthorizeAdminRole(ctx, authUserID); err != nil {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return nil, err
 	}
 

--- a/service/user_test.go
+++ b/service/user_test.go
@@ -30,7 +30,7 @@ func TestUserService_Get(t *testing.T) {
 			setupMocks: func() (*svcmock.AuthService, *repomock.UserRepository) {
 				mockAuthSvc := new(svcmock.AuthService)
 				mockUserRepo := new(repomock.UserRepository)
-				mockAuthSvc.On("AuthorizeAdminRole", mock.Anything, authUserID).Return(nil)
+				mockAuthSvc.On("AuthorizeUserRoleAdmin", mock.Anything, authUserID).Return(nil)
 				mockUserRepo.On("Read", mock.Anything, testUserID).Return(testUser, nil)
 				return mockAuthSvc, mockUserRepo
 			},
@@ -41,7 +41,7 @@ func TestUserService_Get(t *testing.T) {
 			setupMocks: func() (*svcmock.AuthService, *repomock.UserRepository) {
 				mockAuthSvc := new(svcmock.AuthService)
 				mockUserRepo := new(repomock.UserRepository)
-				mockAuthSvc.On("AuthorizeAdminRole", mock.Anything, authUserID).Return(errors.New("test error"))
+				mockAuthSvc.On("AuthorizeUserRoleAdmin", mock.Anything, authUserID).Return(errors.New("test error"))
 				return mockAuthSvc, mockUserRepo
 			},
 			expectErr: true,
@@ -80,7 +80,7 @@ func TestUserService_GetAll(t *testing.T) {
 			setupMocks: func() (*svcmock.AuthService, *repomock.UserRepository) {
 				mockAuthSvc := new(svcmock.AuthService)
 				mockUserRepo := new(repomock.UserRepository)
-				mockAuthSvc.On("AuthorizeAdminRole", mock.Anything, authUserID).Return(nil)
+				mockAuthSvc.On("AuthorizeUserRoleAdmin", mock.Anything, authUserID).Return(nil)
 				mockUserRepo.On("ReadAll", mock.Anything).Return(users, nil)
 				return mockAuthSvc, mockUserRepo
 			},
@@ -91,7 +91,7 @@ func TestUserService_GetAll(t *testing.T) {
 			setupMocks: func() (*svcmock.AuthService, *repomock.UserRepository) {
 				mockAuthSvc := new(svcmock.AuthService)
 				mockUserRepo := new(repomock.UserRepository)
-				mockAuthSvc.On("AuthorizeAdminRole", mock.Anything, authUserID).Return(errors.New("test error"))
+				mockAuthSvc.On("AuthorizeUserRoleAdmin", mock.Anything, authUserID).Return(errors.New("test error"))
 				return mockAuthSvc, mockUserRepo
 			},
 			expectErr: true,
@@ -130,7 +130,7 @@ func TestUserService_Delete(t *testing.T) {
 			setupMocks: func() (*svcmock.AuthService, *repomock.UserRepository) {
 				mockAuthSvc := new(svcmock.AuthService)
 				mockUserRepo := new(repomock.UserRepository)
-				mockAuthSvc.On("AuthorizeAdminRole", mock.Anything, authUserID).Return(nil)
+				mockAuthSvc.On("AuthorizeUserRoleAdmin", mock.Anything, authUserID).Return(nil)
 				mockUserRepo.On("Read", mock.Anything, mock.Anything, mock.Anything).Return(model.User{}, nil)
 				mockUserRepo.On("Delete", mock.Anything, testUserID).Return(nil)
 				return mockAuthSvc, mockUserRepo
@@ -142,7 +142,7 @@ func TestUserService_Delete(t *testing.T) {
 			setupMocks: func() (*svcmock.AuthService, *repomock.UserRepository) {
 				mockAuthSvc := new(svcmock.AuthService)
 				mockUserRepo := new(repomock.UserRepository) // Even if not used, included for consistency
-				mockAuthSvc.On("AuthorizeAdminRole", mock.Anything, authUserID).Return(errors.New("test error"))
+				mockAuthSvc.On("AuthorizeUserRoleAdmin", mock.Anything, authUserID).Return(errors.New("test error"))
 				return mockAuthSvc, mockUserRepo
 			},
 			expectErr: true,
@@ -152,7 +152,7 @@ func TestUserService_Delete(t *testing.T) {
 			setupMocks: func() (*svcmock.AuthService, *repomock.UserRepository) {
 				mockAuthSvc := new(svcmock.AuthService)
 				mockUserRepo := new(repomock.UserRepository)
-				mockAuthSvc.On("AuthorizeAdminRole", mock.Anything, authUserID).Return(nil)
+				mockAuthSvc.On("AuthorizeUserRoleAdmin", mock.Anything, authUserID).Return(nil)
 				mockUserRepo.On("Read", mock.Anything, mock.Anything, mock.Anything).Return(model.User{}, dberrors.NewNotFoundError())
 				return mockAuthSvc, mockUserRepo
 			},


### PR DESCRIPTION
PR adds authorization functions:
- `AuthorizeProjectRoleEditor`
- `AuthorizeProjectRoleViewer`

Also renames functions:
`AuthorizeAdminRole` -> `AuthorizeUserRoleAdmin`
`AuthorizeRole` -> `AuthorizeUserRole`

To keep PR smaller, project authorization functions will be added to services in separate PR once this one is merged.

