### PR TITLE
feat: add create release endpoint

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -41,10 +41,11 @@ func main() {
 		repo.User,
 		repo.Project,
 		repo.Settings,
+		repo.Release,
 		githubClient,
 		resendClient,
 	)
-	h := handler.NewHandler(svc.Auth, svc.User, svc.Project, svc.Settings)
+	h := handler.NewHandler(svc.Auth, svc.User, svc.Project, svc.Settings, svc.Release)
 
 	serverConfig := httpx.ServerConfig{
 		Addr: fmt.Sprintf(":%d", cfg.Port),

--- a/pkg/apierrors/apierrors.go
+++ b/pkg/apierrors/apierrors.go
@@ -27,6 +27,7 @@ var (
 	errCodeGithubRepositoryNotFound                = "ERR_GITHUB_REPOSITORY_NOT_FOUND"
 	errCodeProjectMemberNotFound                   = "ERR_PROJECT_MEMBER_NOT_FOUND"
 	errCodeProjectMemberUnprocessable              = "ERR_PROJECT_MEMBER_UNPROCESSABLE"
+	errCodeReleaseUnprocessable                    = "ERR_RELEASE_UNPROCESSABLE"
 )
 
 type APIError struct {
@@ -199,6 +200,13 @@ func NewProjectMemberUnprocessableError() *APIError {
 	}
 }
 
+func NewReleaseUnprocessableError() *APIError {
+	return &APIError{
+		Code:    errCodeReleaseUnprocessable,
+		Message: "Release unprocessable",
+	}
+}
+
 func IsErrorWithCode(err error, code string) bool {
 	var apiErr *APIError
 	if errors.As(err, &apiErr) {
@@ -224,7 +232,8 @@ func IsUnprocessableModelError(err error) bool {
 		IsErrorWithCode(err, errCodeEnvironmentUnprocessable) ||
 		IsErrorWithCode(err, errCodeSettingsUnprocessable) ||
 		IsErrorWithCode(err, errCodeProjectInvitationUnprocessable) ||
-		IsErrorWithCode(err, errCodeProjectMemberUnprocessable)
+		IsErrorWithCode(err, errCodeProjectMemberUnprocessable) ||
+		IsErrorWithCode(err, errCodeReleaseUnprocessable)
 }
 
 func IsUnauthorizedError(err error) bool {

--- a/repository/mock/release.go
+++ b/repository/mock/release.go
@@ -1,0 +1,18 @@
+package mock
+
+import (
+	"context"
+
+	svcmodel "release-manager/service/model"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type ReleaseRepository struct {
+	mock.Mock
+}
+
+func (m *ReleaseRepository) Create(ctx context.Context, rls svcmodel.Release) error {
+	args := m.Called(ctx, rls)
+	return args.Error(0)
+}

--- a/repository/model/release.go
+++ b/repository/model/release.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"time"
+
+	svcmodel "release-manager/service/model"
+
+	"github.com/google/uuid"
+)
+
+type Release struct {
+	ID           uuid.UUID `json:"id"`
+	ProjectID    uuid.UUID `json:"project_id"`
+	ReleaseTitle string    `json:"release_title"`
+	ReleaseNotes string    `json:"release_notes"`
+	AuthorUserID uuid.UUID `json:"created_by"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+func ToRelease(r svcmodel.Release) Release {
+	return Release{
+		ID:           r.ID,
+		ProjectID:    r.ProjectID,
+		ReleaseTitle: r.ReleaseTitle,
+		ReleaseNotes: r.ReleaseNotes,
+		AuthorUserID: r.AuthorUserID,
+		CreatedAt:    r.CreatedAt,
+		UpdatedAt:    r.UpdatedAt,
+	}
+}

--- a/repository/release.go
+++ b/repository/release.go
@@ -1,0 +1,37 @@
+package repository
+
+import (
+	"context"
+
+	"release-manager/repository/model"
+	"release-manager/repository/util"
+	svcmodel "release-manager/service/model"
+
+	"github.com/nedpals/supabase-go"
+)
+
+const releaseDBEntity = "releases"
+
+type ReleaseRepository struct {
+	client *supabase.Client
+}
+
+func NewReleaseRepository(c *supabase.Client) *ReleaseRepository {
+	return &ReleaseRepository{
+		client: c,
+	}
+}
+
+func (r *ReleaseRepository) Create(ctx context.Context, rls svcmodel.Release) error {
+	data := model.ToRelease(rls)
+
+	err := r.client.
+		DB.From(releaseDBEntity).
+		Insert(&data).
+		ExecuteWithContext(ctx, nil)
+	if err != nil {
+		return util.ToDBError(err)
+	}
+
+	return nil
+}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -7,6 +7,7 @@ type Repository struct {
 	User     *UserRepository
 	Project  *ProjectRepository
 	Settings *SettingsRepository
+	Release  *ReleaseRepository
 }
 
 func NewRepository(client *supabase.Client) *Repository {
@@ -15,5 +16,6 @@ func NewRepository(client *supabase.Client) *Repository {
 		User:     NewUserRepository(client),
 		Project:  NewProjectRepository(client),
 		Settings: NewSettingsRepository(client),
+		Release:  NewReleaseRepository(client),
 	}
 }

--- a/service/mock/project.go
+++ b/service/mock/project.go
@@ -13,7 +13,7 @@ type ProjectService struct {
 	mock.Mock
 }
 
-func (m *ProjectService) Get(ctx context.Context, projectID, authUserID uuid.UUID) (model.Project, error) {
+func (m *ProjectService) GetProject(ctx context.Context, projectID, authUserID uuid.UUID) (model.Project, error) {
 	args := m.Called(ctx, projectID, authUserID)
 	return args.Get(0).(model.Project), args.Error(1)
 }

--- a/service/model/release.go
+++ b/service/model/release.go
@@ -1,0 +1,55 @@
+package model
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var (
+	errReleaseTitleRequired = errors.New("release title is required")
+)
+
+type CreateReleaseInput struct {
+	ReleaseTitle string
+	ReleaseNotes string
+}
+
+type Release struct {
+	ID           uuid.UUID
+	ProjectID    uuid.UUID
+	ReleaseTitle string
+	ReleaseNotes string
+	AuthorUserID uuid.UUID
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	// TODO add source code link
+}
+
+func NewRelease(input CreateReleaseInput, projectID, authorUserID uuid.UUID) (Release, error) {
+	now := time.Now()
+	r := Release{
+		ID:           uuid.New(),
+		ProjectID:    projectID,
+		ReleaseTitle: input.ReleaseTitle,
+		ReleaseNotes: input.ReleaseNotes,
+		AuthorUserID: authorUserID,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+
+	if err := r.Validate(); err != nil {
+		return Release{}, err
+	}
+
+	return r, nil
+}
+
+func (r *Release) Validate() error {
+	if r.ReleaseTitle == "" {
+		return errReleaseTitleRequired
+	}
+
+	return nil
+}

--- a/service/model/release_test.go
+++ b/service/model/release_test.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRelease_NewRelease(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   CreateReleaseInput
+		wantErr bool
+	}{
+		{
+			name: "Valid Release",
+			input: CreateReleaseInput{
+				ReleaseTitle: "Release 1.0",
+				ReleaseNotes: "Initial release",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid Release - Empty ReleaseTitle",
+			input: CreateReleaseInput{
+				ReleaseTitle: "",
+				ReleaseNotes: "Initial release",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewRelease(tt.input, uuid.New(), uuid.New())
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/service/release.go
+++ b/service/release.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"context"
+
+	"release-manager/pkg/apierrors"
+	"release-manager/service/model"
+
+	"github.com/google/uuid"
+)
+
+type ReleaseService struct {
+	projectGetter projectGetter
+	repo          releaseRepository
+}
+
+func NewReleaseService(projectGetter projectGetter, repo releaseRepository) *ReleaseService {
+	return &ReleaseService{
+		projectGetter: projectGetter,
+		repo:          repo,
+	}
+}
+
+func (s *ReleaseService) Create(ctx context.Context, input model.CreateReleaseInput, projectID, authorUserID uuid.UUID) (model.Release, error) {
+	// TODO add project member authorization
+
+	// More features are going to be added, project object will be needed here, therefore GetProject is called here (instead of projectExists)
+	_, err := s.projectGetter.GetProject(ctx, projectID, authorUserID)
+	if err != nil {
+		return model.Release{}, err
+	}
+
+	rls, err := model.NewRelease(input, projectID, authorUserID)
+	if err != nil {
+		return model.Release{}, apierrors.NewReleaseUnprocessableError().Wrap(err).WithMessage(err.Error())
+	}
+
+	// TODO check if release name is unique per project
+
+	if err := s.repo.Create(ctx, rls); err != nil {
+		return model.Release{}, err
+	}
+
+	return rls, nil
+}

--- a/service/release_test.go
+++ b/service/release_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"release-manager/pkg/dberrors"
+	repo "release-manager/repository/mock"
+	svc "release-manager/service/mock"
+	"release-manager/service/model"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestReleaseService_Release(t *testing.T) {
+	testCases := []struct {
+		name      string
+		release   model.CreateReleaseInput
+		mockSetup func(*svc.ProjectService, *repo.ReleaseRepository)
+		wantErr   bool
+	}{
+		{
+			name: "Valid release",
+			release: model.CreateReleaseInput{
+				ReleaseTitle: "Test release",
+				ReleaseNotes: "Test release notes",
+			},
+			mockSetup: func(projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
+				projectSvc.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
+				releaseRepo.On("Create", mock.Anything, mock.Anything).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "Unknown project",
+			release: model.CreateReleaseInput{
+				ReleaseTitle: "Release",
+				ReleaseNotes: "Test release notes",
+			},
+			mockSetup: func(projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
+				projectSvc.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, dberrors.NewNotFoundError())
+			},
+			wantErr: true,
+		},
+		{
+			name: "Missing release title",
+			release: model.CreateReleaseInput{
+				ReleaseTitle: "",
+				ReleaseNotes: "Test release notes",
+			},
+			mockSetup: func(projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
+				projectSvc.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			projectSvc := new(svc.ProjectService)
+			releaseRepo := new(repo.ReleaseRepository)
+			service := NewReleaseService(projectSvc, releaseRepo)
+
+			tc.mockSetup(projectSvc, releaseRepo)
+
+			_, err := service.Create(context.TODO(), tc.release, uuid.New(), uuid.New())
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			projectSvc.AssertExpectations(t)
+			releaseRepo.AssertExpectations(t)
+		})
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -54,6 +54,10 @@ type settingsRepository interface {
 	Read(ctx context.Context) (model.Settings, error)
 }
 
+type releaseRepository interface {
+	Create(ctx context.Context, r model.Release) error
+}
+
 type authGuard interface {
 	AuthorizeUserRoleAdmin(ctx context.Context, userID uuid.UUID) error
 	AuthorizeUserRole(ctx context.Context, userID uuid.UUID, model model.UserRole) error
@@ -68,6 +72,10 @@ type settingsGetter interface {
 type userGetter interface {
 	Get(ctx context.Context, userID, authUserID uuid.UUID) (model.User, error)
 	GetByEmail(ctx context.Context, email string) (model.User, error)
+}
+
+type projectGetter interface {
+	GetProject(ctx context.Context, projectID uuid.UUID, authUserID uuid.UUID) (model.Project, error)
 }
 
 type projectInvitationSender interface {
@@ -88,6 +96,7 @@ type Service struct {
 	User     *UserService
 	Project  *ProjectService
 	Settings *SettingsService
+	Release  *ReleaseService
 }
 
 func NewService(
@@ -95,6 +104,7 @@ func NewService(
 	userRepo userRepository,
 	projectRepo projectRepository,
 	settingsRepo settingsRepository,
+	releaseRepo releaseRepository,
 	githubRepoManager githubRepositoryManager,
 	emailSender emailSender,
 ) *Service {
@@ -103,11 +113,13 @@ func NewService(
 	settingsSvc := NewSettingsService(authSvc, settingsRepo)
 	emailSvc := NewEmailService(emailSender)
 	projectSvc := NewProjectService(authSvc, settingsSvc, userSvc, githubRepoManager, emailSvc, projectRepo)
+	releaseSvc := NewReleaseService(projectSvc, releaseRepo)
 
 	return &Service{
 		Auth:     authSvc,
 		User:     userSvc,
 		Project:  projectSvc,
 		Settings: settingsSvc,
+		Release:  releaseSvc,
 	}
 }

--- a/supabase/migrations/20240505115913_releases.sql
+++ b/supabase/migrations/20240505115913_releases.sql
@@ -1,0 +1,13 @@
+CREATE TABLE public.releases (
+     id UUID NOT NULL PRIMARY KEY,
+     project_id UUID NOT NULL REFERENCES public.projects ON DELETE CASCADE,
+     release_title TEXT NOT NULL,
+     release_notes TEXT,
+     created_by UUID REFERENCES public.users ON DELETE SET NULL,
+     created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+     updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+     CONSTRAINT unique_release_title_per_project UNIQUE (project_id, release_title)
+);
+
+GRANT DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE
+    ON TABLE public.releases TO service_role;

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -51,26 +51,33 @@ type settingsService interface {
 	Get(ctx context.Context, authUserID uuid.UUID) (svcmodel.Settings, error)
 }
 
+type releaseService interface {
+	Create(ctx context.Context, input svcmodel.CreateReleaseInput, projectID, authorUserID uuid.UUID) (svcmodel.Release, error)
+}
+
 type Handler struct {
 	Mux         *chi.Mux
 	AuthSvc     authService
 	UserSvc     userService
 	ProjectSvc  projectService
 	SettingsSvc settingsService
+	ReleaseSvc  releaseService
 }
 
 func NewHandler(
-	as authService,
-	us userService,
-	ps projectService,
-	ss settingsService,
+	authSvc authService,
+	userSvc userService,
+	projectSvc projectService,
+	settingsSvc settingsService,
+	releaseSvc releaseService,
 ) *Handler {
 	h := &Handler{
 		Mux:         chi.NewRouter(),
-		AuthSvc:     as,
-		UserSvc:     us,
-		ProjectSvc:  ps,
-		SettingsSvc: ss,
+		AuthSvc:     authSvc,
+		UserSvc:     userSvc,
+		ProjectSvc:  projectSvc,
+		SettingsSvc: settingsSvc,
+		ReleaseSvc:  releaseSvc,
 	}
 
 	h.setupRoutes()

--- a/transport/handler/release.go
+++ b/transport/handler/release.go
@@ -1,0 +1,30 @@
+package handler
+
+import (
+	"net/http"
+
+	"release-manager/pkg/responseerrors"
+	"release-manager/transport/model"
+	"release-manager/transport/util"
+)
+
+func (h *Handler) createRelease(w http.ResponseWriter, r *http.Request) {
+	var input model.CreateReleaseInput
+	if err := util.UnmarshalRequest(r, &input); err != nil {
+		util.WriteResponseError(w, responseerrors.NewBadRequestError().Wrap(err).WithMessage(err.Error()))
+		return
+	}
+
+	rls, err := h.ReleaseSvc.Create(
+		r.Context(),
+		model.ToSvcCreateReleaseInput(input),
+		util.ContextProjectID(r),
+		util.ContextAuthUserID(r),
+	)
+	if err != nil {
+		util.WriteResponseError(w, util.ToResponseError(err))
+		return
+	}
+
+	util.WriteJSONResponse(w, http.StatusCreated, model.ToRelease(rls))
+}

--- a/transport/handler/routes.go
+++ b/transport/handler/routes.go
@@ -60,6 +60,9 @@ func (h *Handler) setupRoutes() {
 				})
 			})
 			r.Get("/repository/tags", middleware.RequireAuthUser(h.listGithubRepositoryTags))
+			r.Route("/releases", func(r chi.Router) {
+				r.Post("/", middleware.RequireAuthUser(h.createRelease))
+			})
 		})
 	})
 

--- a/transport/model/release.go
+++ b/transport/model/release.go
@@ -1,0 +1,39 @@
+package model
+
+import (
+	"time"
+
+	svcmodel "release-manager/service/model"
+
+	"github.com/google/uuid"
+)
+
+type CreateReleaseInput struct {
+	ReleaseTitle string `json:"release_title"`
+	ReleaseNotes string `json:"release_notes"`
+}
+
+type Release struct {
+	ID           uuid.UUID `json:"id"`
+	ReleaseTitle string    `json:"release_title"`
+	ReleaseNotes string    `json:"release_notes"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+func ToSvcCreateReleaseInput(r CreateReleaseInput) svcmodel.CreateReleaseInput {
+	return svcmodel.CreateReleaseInput{
+		ReleaseTitle: r.ReleaseTitle,
+		ReleaseNotes: r.ReleaseNotes,
+	}
+}
+
+func ToRelease(r svcmodel.Release) Release {
+	return Release{
+		ID:           r.ID,
+		ReleaseTitle: r.ReleaseTitle,
+		ReleaseNotes: r.ReleaseNotes,
+		CreatedAt:    r.CreatedAt,
+		UpdatedAt:    r.UpdatedAt,
+	}
+}


### PR DESCRIPTION
To keep the PR smaller, this PR introduces a very basic Release entity, consisting only of a name and release notes, and adds an endpoint for creating a release. 

Once this is merged, more features can be developed simultaneously, such as new endpoints, Slack notifications, and linking source code (GitHub integration).
