### PR TITLE
feat: add slack integration

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -983,10 +983,10 @@ components:
             show_project_name:
               type: boolean
               default: false
-            show_release_name:
+            show_release_title:
               type: boolean
               default: false
-            show_changelog:
+            show_release_notes:
               type: boolean
               default: false
             show_deployments:

--- a/go.mod
+++ b/go.mod
@@ -24,10 +24,12 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/kamilsk/retry/v5 v5.0.0-rc8 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/slack-go/slack v0.12.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/net v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,7 +13,9 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.19.0 h1:ol+5Fu+cSq9JD7SoSqe04GMI92cbn0+wvQ3bZ8b/AU4=
 github.com/go-playground/validator/v10 v10.19.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v60 v60.0.0 h1:oLG98PsLauFvvu4D/YPxq374jhSxFYdzQGNCyONLfn8=
@@ -22,6 +24,8 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jan-zabloudil/postgrest-go v0.1.4-0.20240504155537-5b7dad2b7e87 h1:0fyBQ0H//wldrJ328bOetR5Tk+qpRWuuJlPK5YeoKU8=
 github.com/jan-zabloudil/postgrest-go v0.1.4-0.20240504155537-5b7dad2b7e87/go.mod h1:RGinB2OXsnGLcZMu5avS0U+b9npyZmk+ecK74UDi/xY=
 github.com/jan-zabloudil/supabase-go v0.0.0-20240229160758-916b4e4b1b63 h1:uI0NCjMzb3/XkxOuEhkbodL4f7+2ldcQpzquoYbCfgk=
@@ -44,8 +48,11 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/sethvargo/go-envconfig v1.0.1 h1:9wglip/5fUfaH0lQecLM8AyOClMw0gT0A9K2c2wozao=
 github.com/sethvargo/go-envconfig v1.0.1/go.mod h1:OKZ02xFaD3MvWBBmEW45fQr08sJEsonGrrOdicvQmQA=
+github.com/slack-go/slack v0.12.5 h1:ddZ6uz6XVaB+3MTDhoW04gG+Vc/M/X1ctC+wssy2cqs=
+github.com/slack-go/slack v0.12.5/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.strv.io/background v0.1.0 h1:29AI5Byj8B55/py8BJECv9fNbgjF+Cd5DYwEywI1qZI=

--- a/repository/model/project.go
+++ b/repository/model/project.go
@@ -41,12 +41,12 @@ type UpdateProjectInput struct {
 }
 
 type ReleaseNotificationConfig struct {
-	Message         string `json:"message"`
-	ShowProjectName bool   `json:"show_project_name"`
-	ShowReleaseName bool   `json:"show_release_name"`
-	ShowChangelog   bool   `json:"show_changelog"`
-	ShowDeployments bool   `json:"show_deployments"`
-	ShowSourceCode  bool   `json:"show_source_code"`
+	Message          string `json:"message"`
+	ShowProjectName  bool   `json:"show_project_name"`
+	ShowReleaseTitle bool   `json:"show_release_title"`
+	ShowReleaseNotes bool   `json:"show_release_notes"`
+	ShowDeployments  bool   `json:"show_deployments"`
+	ShowSourceCode   bool   `json:"show_source_code"`
 }
 
 type GithubRepository struct {

--- a/service/model/project.go
+++ b/service/model/project.go
@@ -38,21 +38,21 @@ type UpdateProjectInput struct {
 }
 
 type ReleaseNotificationConfig struct {
-	Message         string
-	ShowProjectName bool
-	ShowReleaseName bool
-	ShowChangelog   bool
-	ShowDeployments bool
-	ShowSourceCode  bool
+	Message          string
+	ShowProjectName  bool
+	ShowReleaseTitle bool
+	ShowReleaseNotes bool
+	ShowDeployments  bool
+	ShowSourceCode   bool
 }
 
 type UpdateReleaseNotificationConfigInput struct {
-	Message         *string
-	ShowProjectName *bool
-	ShowReleaseName *bool
-	ShowChangelog   *bool
-	ShowDeployments *bool
-	ShowSourceCode  *bool
+	Message          *string
+	ShowProjectName  *bool
+	ShowReleaseTitle *bool
+	ShowReleaseNotes *bool
+	ShowDeployments  *bool
+	ShowSourceCode   *bool
 }
 
 func NewProject(c CreateProjectInput) (Project, error) {
@@ -124,11 +124,11 @@ func (c *ReleaseNotificationConfig) Update(u UpdateReleaseNotificationConfigInpu
 	if u.ShowProjectName != nil {
 		c.ShowProjectName = *u.ShowProjectName
 	}
-	if u.ShowReleaseName != nil {
-		c.ShowReleaseName = *u.ShowReleaseName
+	if u.ShowReleaseTitle != nil {
+		c.ShowReleaseTitle = *u.ShowReleaseTitle
 	}
-	if u.ShowChangelog != nil {
-		c.ShowChangelog = *u.ShowChangelog
+	if u.ShowReleaseNotes != nil {
+		c.ShowReleaseNotes = *u.ShowReleaseNotes
 	}
 	if u.ShowDeployments != nil {
 		c.ShowDeployments = *u.ShowDeployments

--- a/service/model/release.go
+++ b/service/model/release.go
@@ -53,3 +53,28 @@ func (r *Release) Validate() error {
 
 	return nil
 }
+
+type ReleaseNotification struct {
+	Message      string
+	ProjectName  *string
+	ReleaseTitle *string
+	ReleaseNotes *string
+}
+
+func NewReleaseNotification(p Project, r Release) ReleaseNotification {
+	n := ReleaseNotification{
+		Message: p.ReleaseNotificationConfig.Message,
+	}
+
+	if p.ReleaseNotificationConfig.ShowProjectName {
+		n.ProjectName = &p.Name
+	}
+	if p.ReleaseNotificationConfig.ShowReleaseTitle {
+		n.ReleaseTitle = &r.ReleaseTitle
+	}
+	if p.ReleaseNotificationConfig.ShowReleaseNotes {
+		n.ReleaseNotes = &r.ReleaseNotes
+	}
+
+	return n
+}

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -215,12 +215,12 @@ func TestProjectService_UpdateProject(t *testing.T) {
 				Name:           &validProjectName,
 				SlackChannelID: &slackChannelID,
 				ReleaseNotificationConfigUpdate: model.UpdateReleaseNotificationConfigInput{
-					Message:         new(string),
-					ShowProjectName: new(bool),
-					ShowReleaseName: new(bool),
-					ShowChangelog:   new(bool),
-					ShowDeployments: new(bool),
-					ShowSourceCode:  new(bool),
+					Message:          new(string),
+					ShowProjectName:  new(bool),
+					ShowReleaseTitle: new(bool),
+					ShowReleaseNotes: new(bool),
+					ShowDeployments:  new(bool),
+					ShowSourceCode:   new(bool),
 				},
 			},
 			mockSetup: func(auth *svc.AuthService, projectRepo *repo.ProjectRepository) {

--- a/service/release.go
+++ b/service/release.go
@@ -36,7 +36,7 @@ func (s *ReleaseService) Create(ctx context.Context, input model.CreateReleaseIn
 	}
 
 	// TODO check if release name is unique per project
-
+	// TODO send slack notification
 	if err := s.repo.Create(ctx, rls); err != nil {
 		return model.Release{}, err
 	}

--- a/slack/client.go
+++ b/slack/client.go
@@ -1,0 +1,61 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+
+	"release-manager/service/model"
+
+	"github.com/slack-go/slack"
+	"go.strv.io/background"
+	"go.strv.io/background/task"
+)
+
+type Client struct {
+	taskManager       *background.Manager
+	msgOptionsBuilder *MsgOptionsBuilder
+}
+
+func NewClient(manager *background.Manager) *Client {
+	return &Client{
+		taskManager:       manager,
+		msgOptionsBuilder: NewMsgOptionsBuilder(),
+	}
+}
+
+func (c *Client) SendReleaseNotification(ctx context.Context, token, channelID string, n model.ReleaseNotification) {
+	msgOptions := c.msgOptionsBuilder.
+		SetMessage(n.Message)
+
+	if n.ProjectName != nil {
+		msgOptions.AddAttachmentField("Project", *n.ProjectName)
+	}
+	if n.ReleaseTitle != nil {
+		msgOptions.AddAttachmentField("Release", *n.ReleaseTitle)
+	}
+	if n.ReleaseNotes != nil {
+		msgOptions.AddAttachmentField("Release notes", *n.ReleaseNotes)
+	}
+
+	c.sendMessageAsync(ctx, token, channelID, msgOptions.Build())
+}
+
+func (c *Client) sendMessageAsync(ctx context.Context, token, channelID string, msgOptions []slack.MsgOption) {
+	client := slack.New(token)
+
+	t := task.Task{
+		Type: task.TypeOneOff,
+		Meta: task.Metadata{
+			"task": "sending slack message",
+		},
+		Fn: func(ctx context.Context) error {
+			if _, _, err := client.PostMessageContext(ctx, channelID, msgOptions...); err != nil {
+				return fmt.Errorf("failed to send message to Slack channel (ID %s): %w", channelID, err)
+			}
+
+			return nil
+		},
+	}
+
+	c.taskManager.RunTask(ctx, t)
+}

--- a/slack/message.go
+++ b/slack/message.go
@@ -1,0 +1,44 @@
+package slack
+
+import (
+	"github.com/slack-go/slack"
+)
+
+type MsgOptionsBuilder struct {
+	msg              string
+	msgParams        slack.PostMessageParameters
+	attachmentFields []slack.AttachmentField
+}
+
+func NewMsgOptionsBuilder() *MsgOptionsBuilder {
+	return &MsgOptionsBuilder{
+		msgParams: slack.PostMessageParameters{Markdown: true}, // message is formatted using Slack's markdown-like syntax
+	}
+}
+
+func (b *MsgOptionsBuilder) SetMessage(msg string) *MsgOptionsBuilder {
+	b.msg = msg
+	return b
+}
+
+func (b *MsgOptionsBuilder) AddAttachmentField(title, value string) *MsgOptionsBuilder {
+	b.attachmentFields = append(b.attachmentFields, slack.AttachmentField{
+		Title: title,
+		Value: value,
+		Short: false, // each field is on the new line
+	})
+
+	return b
+}
+
+func (b *MsgOptionsBuilder) Build() []slack.MsgOption {
+	attachment := slack.Attachment{
+		Pretext: b.msg,
+		Fields:  b.attachmentFields,
+	}
+
+	return []slack.MsgOption{
+		slack.MsgOptionAttachments(attachment),
+		slack.MsgOptionPostMessageParameters(b.msgParams),
+	}
+}

--- a/transport/model/project.go
+++ b/transport/model/project.go
@@ -33,21 +33,21 @@ type Project struct {
 }
 
 type ReleaseNotificationConfig struct {
-	Message         string `json:"message"`
-	ShowProjectName bool   `json:"show_project_name"`
-	ShowReleaseName bool   `json:"show_release_name"`
-	ShowChangelog   bool   `json:"show_changelog"`
-	ShowDeployments bool   `json:"show_deployments"`
-	ShowSourceCode  bool   `json:"show_source_code"`
+	Message          string `json:"message"`
+	ShowProjectName  bool   `json:"show_project_name"`
+	ShowReleaseTitle bool   `json:"show_release_title"`
+	ShowReleaseNotes bool   `json:"show_release_notes"`
+	ShowDeployments  bool   `json:"show_deployments"`
+	ShowSourceCode   bool   `json:"show_source_code"`
 }
 
 type UpdateReleaseNotificationConfigInput struct {
-	Message         *string `json:"message"`
-	ShowProjectName *bool   `json:"show_project_name"`
-	ShowReleaseName *bool   `json:"show_release_name"`
-	ShowChangelog   *bool   `json:"show_changelog"`
-	ShowDeployments *bool   `json:"show_deployments"`
-	ShowSourceCode  *bool   `json:"show_source_code"`
+	Message          *string `json:"message"`
+	ShowProjectName  *bool   `json:"show_project_name"`
+	ShowReleaseTitle *bool   `json:"show_release_title"`
+	ShowReleaseNotes *bool   `json:"show_release_notes"`
+	ShowDeployments  *bool   `json:"show_deployments"`
+	ShowSourceCode   *bool   `json:"show_source_code"`
 }
 
 func ToSvcCreateProjectInput(c CreateProjectInput) svcmodel.CreateProjectInput {


### PR DESCRIPTION
This PR introduces the ability to send Slack messages from the app in the following format: message + [message attachment](https://api.slack.com/reference/messaging/attachments)

<img width="574" alt="Snímek obrazovky 2024-05-06 v 9 51 58" src="https://github.com/jan-zabloudil/release-manager/assets/81581922/8b101200-5ac4-45b9-b23f-da18ed9323eb">
