### PR TITLE
refactor(repository): use db pool in ReadInvitationByEmail function

### DIFF
--- a/repository/mock/project.go
+++ b/repository/mock/project.go
@@ -74,7 +74,7 @@ func (m *ProjectRepository) CreateInvitation(ctx context.Context, i svcmodel.Pro
 	return args.Error(0)
 }
 
-func (m *ProjectRepository) ReadInvitationByEmailForProject(ctx context.Context, email string, projectID uuid.UUID) (svcmodel.ProjectInvitation, error) {
+func (m *ProjectRepository) ReadInvitationByEmail(ctx context.Context, email string, projectID uuid.UUID) (svcmodel.ProjectInvitation, error) {
 	args := m.Called(ctx, email, projectID)
 	return args.Get(0).(svcmodel.ProjectInvitation), args.Error(1)
 }

--- a/repository/model/project_invitation.go
+++ b/repository/model/project_invitation.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// TODO once all functions are using db pool, remove json tags
+// TODO remove json tags once all functions use db pool
 type ProjectInvitation struct {
 	ID            uuid.UUID `json:"id" db:"id"`
 	ProjectID     uuid.UUID `json:"project_id" db:"project_id"`

--- a/repository/query/query.go
+++ b/repository/query/query.go
@@ -33,6 +33,8 @@ var (
 	//go:embed scripts/update_project.sql
 	UpdateProject string
 
+	//go:embed scripts/read_invitation_by_email.sql
+	ReadInvitationByEmail string
 	//go:embed scripts/list_invitations_for_project.sql
 	ListInvitationsForProject string
 	//go:embed scripts/delete_invitation.sql

--- a/repository/query/scripts/read_invitation_by_email.sql
+++ b/repository/query/scripts/read_invitation_by_email.sql
@@ -1,0 +1,5 @@
+SELECT *
+FROM project_invitations
+WHERE
+    project_id = @projectID AND
+    email = @email

--- a/service/project.go
+++ b/service/project.go
@@ -450,8 +450,8 @@ func (s *ProjectService) getPendingInvitationByToken(ctx context.Context, tkn cr
 }
 
 func (s *ProjectService) invitationExists(ctx context.Context, email string, projectID uuid.UUID) (bool, error) {
-	if _, err := s.repo.ReadInvitationByEmailForProject(ctx, email, projectID); err != nil {
-		if dberrors.IsNotFoundError(err) {
+	if _, err := s.repo.ReadInvitationByEmail(ctx, email, projectID); err != nil {
+		if apierrors.IsNotFoundError(err) {
 			return false, nil
 		}
 

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -754,8 +754,9 @@ func TestProjectService_Invite(t *testing.T) {
 			mockSetup: func(auth *svc.AuthorizeService, user *svc.UserService, email *resendmock.Client, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
+				user.On("GetByEmail", mock.Anything, mock.Anything).Return(model.User{}, apierrors.NewUserNotFoundError()) // case when user do not exist at all
+				projectRepo.On("ReadInvitationByEmail", mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectInvitation{}, nil)
 				projectRepo.On("ReadMemberByEmail", mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectMember{}, apierrors.NewProjectMemberNotFoundError())
-				projectRepo.On("ReadInvitationByEmailForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectInvitation{}, nil)
 			},
 			wantErr: true,
 		},
@@ -770,7 +771,7 @@ func TestProjectService_Invite(t *testing.T) {
 				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				projectRepo.On("ReadProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
 				projectRepo.On("ReadMemberByEmail", mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectMember{}, apierrors.NewProjectMemberNotFoundError())
-				projectRepo.On("ReadInvitationByEmailForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectInvitation{}, dberrors.NewNotFoundError())
+				projectRepo.On("ReadInvitationByEmail", mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectInvitation{}, apierrors.NewProjectInvitationNotFoundError())
 				projectRepo.On("CreateInvitation", mock.Anything, mock.Anything).Return(nil)
 				email.On("SendEmailAsync", mock.Anything, mock.Anything)
 			},

--- a/service/service.go
+++ b/service/service.go
@@ -27,7 +27,7 @@ type projectRepository interface {
 	CreateInvitation(ctx context.Context, i model.ProjectInvitation) error
 	ListInvitationsForProject(ctx context.Context, projectID uuid.UUID) ([]model.ProjectInvitation, error)
 	ReadInvitationByTokenHashAndStatus(ctx context.Context, hash cryptox.Hash, status model.ProjectInvitationStatus) (model.ProjectInvitation, error)
-	ReadInvitationByEmailForProject(ctx context.Context, email string, projectID uuid.UUID) (model.ProjectInvitation, error)
+	ReadInvitationByEmail(ctx context.Context, email string, projectID uuid.UUID) (model.ProjectInvitation, error)
 	DeleteInvitation(ctx context.Context, projectID, invitationID uuid.UUID) error
 	DeleteInvitationByTokenHashAndStatus(ctx context.Context, hash cryptox.Hash, status model.ProjectInvitationStatus) error
 	UpdateInvitation(ctx context.Context, i model.ProjectInvitation) error


### PR DESCRIPTION
There is one more repo read invitatio function `ReadInvitationByTokenHashAndStatus` but this one will be refactored in separate PR (as part of accept invitation refactoring) once this one is merged. 