### PR TITLE
feat: add sorting criteria to listing queries

### DIFF
--- a/repository/query/scripts/list_environments_for_project.sql
+++ b/repository/query/scripts/list_environments_for_project.sql
@@ -1,3 +1,4 @@
 SELECT *
 FROM environments
 WHERE project_id = @projectID
+ORDER BY name

--- a/repository/query/scripts/list_members_for_project.sql
+++ b/repository/query/scripts/list_members_for_project.sql
@@ -14,3 +14,4 @@ FROM project_members pm
 JOIN users u ON u.id = pm.user_id
 WHERE
     pm.project_id = @projectID
+ORDER BY u.name

--- a/repository/query/scripts/list_users.sql
+++ b/repository/query/scripts/list_users.sql
@@ -1,2 +1,3 @@
 SELECT *
 FROM users
+ORDER BY name


### PR DESCRIPTION
I think for users list and project members list it makes sense to order records by user's name.

In case of environments you usually want order: dev, test, staging, prod - so I will probably add `order` column to `environment` entity (in separate PR). For now environments are sorted by name as well.