### PR TITLE
feat: send release notification via Slack

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -12,6 +12,7 @@ import (
 	"release-manager/repository"
 	resendx "release-manager/resend"
 	"release-manager/service"
+	"release-manager/slack"
 	"release-manager/transport/handler"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -44,6 +45,7 @@ func run() error {
 	githubClient := githubx.NewClient()
 	resendClient := resendx.NewClient(taskManager, cfg.Resend)
 	authClient := auth.NewClient(supaClient)
+	slackClient := slack.NewClient(taskManager)
 
 	dbpool, err := pgxpool.New(ctx, cfg.Supabase.DatabaseURL)
 	if err != nil {
@@ -63,6 +65,7 @@ func run() error {
 		repo.Release,
 		githubClient,
 		resendClient,
+		slackClient,
 	)
 	h := handler.NewHandler(authClient, svc.User, svc.Project, svc.Settings, svc.Release)
 

--- a/pkg/apierrors/apierrors.go
+++ b/pkg/apierrors/apierrors.go
@@ -3,6 +3,7 @@ package apierrors
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 )
 
 var (
@@ -31,6 +32,7 @@ var (
 	errCodeProjectMemberUnprocessable              = "ERR_PROJECT_MEMBER_UNPROCESSABLE"
 	errCodeReleaseUnprocessable                    = "ERR_RELEASE_UNPROCESSABLE"
 	errCodeReleaseNotFound                         = "ERR_RELEASE_NOT_FOUND"
+	errCodeSlackIntegrationNotEnabled              = "ERR_SLACK_INTEGRATION_NOT_ENABLED"
 )
 
 type APIError struct {
@@ -231,6 +233,13 @@ func NewReleaseNotFoundError() *APIError {
 	}
 }
 
+func NewSlackIntegrationNotEnabledError() *APIError {
+	return &APIError{
+		Code:    errCodeSlackIntegrationNotEnabled,
+		Message: "Slack integration is not enabled.",
+	}
+}
+
 func IsErrorWithCode(err error, code string) bool {
 	var apiErr *APIError
 	if errors.As(err, &apiErr) {
@@ -279,4 +288,16 @@ func IsConflictError(err error) bool {
 	return IsErrorWithCode(err, errCodeEnvironmentDuplicateName) ||
 		IsErrorWithCode(err, errCodeProjectInvitationAlreadyExists) ||
 		IsErrorWithCode(err, errCodeProjectMemberAlreadyExists)
+}
+
+func IsSlackIntegrationNotEnabledError(err error) bool {
+	return IsErrorWithCode(err, errCodeSlackIntegrationNotEnabled)
+}
+
+func GetLogLevel(err error) slog.Level {
+	if IsSlackIntegrationNotEnabledError(err) {
+		return slog.LevelDebug
+	}
+
+	return slog.LevelError
 }

--- a/service/mock/settings.go
+++ b/service/mock/settings.go
@@ -27,3 +27,8 @@ func (m *SettingsService) GetGithubToken(ctx context.Context) (string, error) {
 	args := m.Called(ctx)
 	return args.Get(0).(string), args.Error(1)
 }
+
+func (m *SettingsService) GetSlackToken(ctx context.Context) (string, error) {
+	args := m.Called(ctx)
+	return args.String(0), args.Error(1)
+}

--- a/service/model/project.go
+++ b/service/model/project.go
@@ -111,7 +111,7 @@ func (p *Project) Validate() error {
 	return nil
 }
 
-func (p *Project) IsSlackConfigured() bool {
+func (p *Project) IsSlackChannelSet() bool {
 	return p.SlackChannelID != ""
 }
 

--- a/service/model/release.go
+++ b/service/model/release.go
@@ -54,6 +54,7 @@ func (r *Release) Validate() error {
 	return nil
 }
 
+// TODO add more fields
 type ReleaseNotification struct {
 	Message      string
 	ProjectName  *string

--- a/service/release.go
+++ b/service/release.go
@@ -100,5 +100,5 @@ func (s *ReleaseService) sendReleaseNotification(ctx context.Context, p model.Pr
 		return
 	}
 
-	s.slackNotifier.SendReleaseNotification(ctx, tkn, p.SlackChannelID, model.NewReleaseNotification(p, rls))
+	s.slackNotifier.SendReleaseNotificationAsync(ctx, tkn, p.SlackChannelID, model.NewReleaseNotification(p, rls))
 }

--- a/service/release.go
+++ b/service/release.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"log/slog"
 
 	"release-manager/pkg/apierrors"
 	"release-manager/service/model"
@@ -10,22 +11,36 @@ import (
 )
 
 type ReleaseService struct {
-	projectGetter projectGetter
-	repo          releaseRepository
+	projectGetter  projectGetter
+	settingsGetter settingsGetter
+	slackNotifier  slackNotifier
+	repo           releaseRepository
 }
 
-func NewReleaseService(projectGetter projectGetter, repo releaseRepository) *ReleaseService {
+func NewReleaseService(
+	projectGetter projectGetter,
+	settingsGetter settingsGetter,
+	notifier slackNotifier,
+	repo releaseRepository,
+) *ReleaseService {
 	return &ReleaseService{
-		projectGetter: projectGetter,
-		repo:          repo,
+		projectGetter:  projectGetter,
+		settingsGetter: settingsGetter,
+		slackNotifier:  notifier,
+		repo:           repo,
 	}
 }
 
-func (s *ReleaseService) Create(ctx context.Context, input model.CreateReleaseInput, projectID, authorUserID uuid.UUID) (model.Release, error) {
+func (s *ReleaseService) Create(
+	ctx context.Context,
+	input model.CreateReleaseInput,
+	sendReleaseNotification bool,
+	projectID,
+	authorUserID uuid.UUID,
+) (model.Release, error) {
 	// TODO add project member authorization
 
-	// More features are going to be added, project object will be needed here, therefore GetProject is called here (instead of projectExists)
-	_, err := s.projectGetter.GetProject(ctx, projectID, authorUserID)
+	p, err := s.projectGetter.GetProject(ctx, projectID, authorUserID)
 	if err != nil {
 		return model.Release{}, err
 	}
@@ -36,9 +51,12 @@ func (s *ReleaseService) Create(ctx context.Context, input model.CreateReleaseIn
 	}
 
 	// TODO check if release name is unique per project
-	// TODO send slack notification
 	if err := s.repo.Create(ctx, rls); err != nil {
 		return model.Release{}, err
+	}
+
+	if sendReleaseNotification {
+		s.sendReleaseNotification(ctx, p, rls)
 	}
 
 	return rls, nil
@@ -63,4 +81,24 @@ func (s *ReleaseService) Delete(ctx context.Context, projectID, releaseID, autho
 	}
 
 	return nil
+}
+
+func (s *ReleaseService) sendReleaseNotification(ctx context.Context, p model.Project, rls model.Release) {
+	if !p.IsSlackChannelSet() {
+		slog.Debug("notification not sent: slack channel missing for project", "project_id", p.ID)
+		return
+	}
+
+	tkn, err := s.settingsGetter.GetSlackToken(ctx)
+	if err != nil {
+		// when fetching slack token fails, just log the error
+		// fail attempt to send Slack notification should not affect the release creation
+		// two possible reasons for failure:
+		// 1. slack integration is not set (logged in debug level, as it's not an error, but possible scenario)
+		// 2. failed to fetch slack token (logged in error level)
+		slog.Log(ctx, apierrors.GetLogLevel(err), "failed to get slack token", "err", err)
+		return
+	}
+
+	s.slackNotifier.SendReleaseNotification(ctx, tkn, p.SlackChannelID, model.NewReleaseNotification(p, rls))
 }

--- a/service/release_test.go
+++ b/service/release_test.go
@@ -50,7 +50,7 @@ func TestReleaseService_Create(t *testing.T) {
 				}, nil)
 				releaseRepo.On("Create", mock.Anything, mock.Anything).Return(nil)
 				settingsSvc.On("GetSlackToken", mock.Anything).Return("token", nil)
-				slackClient.On("SendReleaseNotification", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+				slackClient.On("SendReleaseNotificationAsync", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 			},
 			wantErr: false,
 		},
@@ -160,8 +160,10 @@ func TestReleaseService_Get(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			projectSvc := new(svc.ProjectService)
+			settingsSvc := new(svc.SettingsService)
 			releaseRepo := new(repo.ReleaseRepository)
-			service := NewReleaseService(projectSvc, releaseRepo)
+			slackClient := new(slack.Client)
+			service := NewReleaseService(projectSvc, settingsSvc, slackClient, releaseRepo)
 
 			tc.mockSetup(releaseRepo)
 
@@ -204,8 +206,10 @@ func TestReleaseService_Delete(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			projectSvc := new(svc.ProjectService)
+			settingsSvc := new(svc.SettingsService)
 			releaseRepo := new(repo.ReleaseRepository)
-			service := NewReleaseService(projectSvc, releaseRepo)
+			slackClient := new(slack.Client)
+			service := NewReleaseService(projectSvc, settingsSvc, slackClient, releaseRepo)
 
 			tc.mockSetup(releaseRepo)
 

--- a/service/service.go
+++ b/service/service.go
@@ -89,7 +89,7 @@ type emailSender interface {
 }
 
 type slackNotifier interface {
-	SendReleaseNotification(ctx context.Context, token, channel string, notification model.ReleaseNotification)
+	SendReleaseNotificationAsync(ctx context.Context, token, channel string, notification model.ReleaseNotification)
 }
 
 type Service struct {

--- a/service/settings.go
+++ b/service/settings.go
@@ -60,3 +60,16 @@ func (s *SettingsService) GetGithubToken(ctx context.Context) (string, error) {
 
 	return settings.Github.Token, nil
 }
+
+func (s *SettingsService) GetSlackToken(ctx context.Context) (string, error) {
+	settings, err := s.repository.Read(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if !settings.Slack.Enabled {
+		return "", apierrors.NewSlackIntegrationNotEnabledError()
+	}
+
+	return settings.Slack.Token, nil
+}

--- a/slack/client.go
+++ b/slack/client.go
@@ -21,7 +21,7 @@ func NewClient(manager *background.Manager) *Client {
 	}
 }
 
-func (c *Client) SendReleaseNotification(ctx context.Context, token, channelID string, n model.ReleaseNotification) {
+func (c *Client) SendReleaseNotificationAsync(ctx context.Context, token, channelID string, n model.ReleaseNotification) {
 	msgOptions := NewMsgOptionsBuilder().
 		SetMessage(n.Message)
 

--- a/slack/client.go
+++ b/slack/client.go
@@ -12,19 +12,17 @@ import (
 )
 
 type Client struct {
-	taskManager       *background.Manager
-	msgOptionsBuilder *MsgOptionsBuilder
+	taskManager *background.Manager
 }
 
 func NewClient(manager *background.Manager) *Client {
 	return &Client{
-		taskManager:       manager,
-		msgOptionsBuilder: NewMsgOptionsBuilder(),
+		taskManager: manager,
 	}
 }
 
 func (c *Client) SendReleaseNotification(ctx context.Context, token, channelID string, n model.ReleaseNotification) {
-	msgOptions := c.msgOptionsBuilder.
+	msgOptions := NewMsgOptionsBuilder().
 		SetMessage(n.Message)
 
 	if n.ProjectName != nil {

--- a/slack/mock/client.go
+++ b/slack/mock/client.go
@@ -12,6 +12,6 @@ type Client struct {
 	mock.Mock
 }
 
-func (m *Client) SendReleaseNotification(ctx context.Context, token, channelID string, n model.ReleaseNotification) {
+func (m *Client) SendReleaseNotificationAsync(ctx context.Context, token, channelID string, n model.ReleaseNotification) {
 	m.Called(ctx, token, channelID, n)
 }

--- a/slack/mock/client.go
+++ b/slack/mock/client.go
@@ -1,0 +1,17 @@
+package slack
+
+import (
+	"context"
+
+	"release-manager/service/model"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type Client struct {
+	mock.Mock
+}
+
+func (m *Client) SendReleaseNotification(ctx context.Context, token, channelID string, n model.ReleaseNotification) {
+	m.Called(ctx, token, channelID, n)
+}

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -48,7 +48,7 @@ type settingsService interface {
 }
 
 type releaseService interface {
-	Create(ctx context.Context, input svcmodel.CreateReleaseInput, projectID, authorUserID uuid.UUID) (svcmodel.Release, error)
+	Create(ctx context.Context, input svcmodel.CreateReleaseInput, sendReleaseNotification bool, projectID, authorUserID uuid.UUID) (svcmodel.Release, error)
 	Get(ctx context.Context, projectID, releaseID, authorUserID uuid.UUID) (svcmodel.Release, error)
 	Delete(ctx context.Context, projectID, releaseID, authorUserID uuid.UUID) error
 }

--- a/transport/handler/release.go
+++ b/transport/handler/release.go
@@ -18,6 +18,7 @@ func (h *Handler) createRelease(w http.ResponseWriter, r *http.Request) {
 	rls, err := h.ReleaseSvc.Create(
 		r.Context(),
 		model.ToSvcCreateReleaseInput(input),
+		input.SendReleaseNotification,
 		util.ContextProjectID(r),
 		util.ContextAuthUserID(r),
 	)

--- a/transport/model/release.go
+++ b/transport/model/release.go
@@ -9,8 +9,9 @@ import (
 )
 
 type CreateReleaseInput struct {
-	ReleaseTitle string `json:"release_title"`
-	ReleaseNotes string `json:"release_notes"`
+	ReleaseTitle            string `json:"release_title"`
+	ReleaseNotes            string `json:"release_notes"`
+	SendReleaseNotification bool   `json:"send_release_notification"`
 }
 
 type Release struct {


### PR DESCRIPTION
When creating a release, you can choose whether to send a notification to Slack or not (feature requirement).