### PR TITLE
refactor: improve accept invitation logic in service; use db pool in repo

### DIFF
--- a/repository/mock/project.go
+++ b/repository/mock/project.go
@@ -79,24 +79,24 @@ func (m *ProjectRepository) CreateInvitation(ctx context.Context, i svcmodel.Pro
 	return args.Error(0)
 }
 
+func (m *ProjectRepository) AcceptPendingInvitation(ctx context.Context, invitationID uuid.UUID, fn svcmodel.AcceptProjectInvitationFunc) error {
+	args := m.Called(ctx, invitationID, fn)
+	return args.Error(0)
+}
+
 func (m *ProjectRepository) ReadInvitationByEmail(ctx context.Context, email string, projectID uuid.UUID) (svcmodel.ProjectInvitation, error) {
 	args := m.Called(ctx, email, projectID)
 	return args.Get(0).(svcmodel.ProjectInvitation), args.Error(1)
 }
 
-func (m *ProjectRepository) ReadInvitationByTokenHashAndStatus(ctx context.Context, hash crypto.Hash, status svcmodel.ProjectInvitationStatus) (svcmodel.ProjectInvitation, error) {
-	args := m.Called(ctx, hash, status)
+func (m *ProjectRepository) ReadPendingInvitationByHash(ctx context.Context, hash crypto.Hash) (svcmodel.ProjectInvitation, error) {
+	args := m.Called(ctx, hash)
 	return args.Get(0).(svcmodel.ProjectInvitation), args.Error(1)
 }
 
 func (m *ProjectRepository) ListInvitationsForProject(ctx context.Context, projectID uuid.UUID) ([]svcmodel.ProjectInvitation, error) {
 	args := m.Called(ctx, projectID)
 	return args.Get(0).([]svcmodel.ProjectInvitation), args.Error(1)
-}
-
-func (m *ProjectRepository) UpdateInvitation(ctx context.Context, i svcmodel.ProjectInvitation) error {
-	args := m.Called(ctx, i)
-	return args.Error(0)
 }
 
 func (m *ProjectRepository) DeleteInvitation(ctx context.Context, projectID, invitationID uuid.UUID) error {

--- a/repository/model/project_invitation.go
+++ b/repository/model/project_invitation.go
@@ -21,11 +21,6 @@ type ProjectInvitation struct {
 	UpdatedAt     time.Time `json:"updated_at" db:"updated_at"`
 }
 
-type UpdateProjectInvitationInput struct {
-	Status    string    `json:"status"`
-	UpdatedAt time.Time `json:"updated_at"`
-}
-
 func ToProjectInvitation(i svcmodel.ProjectInvitation) ProjectInvitation {
 	return ProjectInvitation{
 		ID:            i.ID,
@@ -37,13 +32,6 @@ func ToProjectInvitation(i svcmodel.ProjectInvitation) ProjectInvitation {
 		InviterUserID: i.InviterUserID,
 		CreatedAt:     i.CreatedAt,
 		UpdatedAt:     i.UpdatedAt,
-	}
-}
-
-func ToUpdateProjectInvitationInput(u svcmodel.ProjectInvitation) UpdateProjectInvitationInput {
-	return UpdateProjectInvitationInput{
-		Status:    string(u.Status),
-		UpdatedAt: u.UpdatedAt,
 	}
 }
 

--- a/repository/query/query.go
+++ b/repository/query/query.go
@@ -41,6 +41,10 @@ var (
 
 	//go:embed scripts/read_invitation_by_email.sql
 	ReadInvitationByEmail string
+	//go:embed scripts/read_invitation_by_id_and_status_for_update.sql
+	ReadInvitationByIDAndStatusForUpdate string
+	//go:embed scripts/read_invitation_by_hash_and_status.sql
+	ReadInvitationByHashAndStatus string
 	//go:embed scripts/list_invitations_for_project.sql
 	ListInvitationsForProject string
 	//go:embed scripts/delete_invitation.sql
@@ -49,6 +53,8 @@ var (
 	DeleteInvitationByEmailAndProjectID string
 	//go:embed scripts/delete_invitation_by_hash_and_status.sql
 	DeleteInvitationByHashAndStatus string
+	//go:embed scripts/update_invitation.sql
+	UpdateInvitation string
 
 	//go:embed scripts/create_member.sql
 	CreateMember string

--- a/repository/query/scripts/read_invitation_by_hash_and_status.sql
+++ b/repository/query/scripts/read_invitation_by_hash_and_status.sql
@@ -1,0 +1,5 @@
+SELECT *
+FROM project_invitations
+WHERE
+    token_hash = @hash AND
+    status = @status

--- a/repository/query/scripts/read_invitation_by_id_and_status_for_update.sql
+++ b/repository/query/scripts/read_invitation_by_id_and_status_for_update.sql
@@ -1,0 +1,6 @@
+SELECT *
+FROM project_invitations
+WHERE
+    id = @id AND
+    status = @status
+FOR UPDATE

--- a/repository/query/scripts/update_invitation.sql
+++ b/repository/query/scripts/update_invitation.sql
@@ -1,0 +1,6 @@
+UPDATE project_invitations
+SET
+    status = @status,
+    updated_at = @updatedAt
+WHERE
+    id = @invitationID

--- a/service/model/project_invitation.go
+++ b/service/model/project_invitation.go
@@ -69,6 +69,8 @@ func NewProjectInvitation(c CreateProjectInvitationInput, tkn cryptox.Token, inv
 	return i, nil
 }
 
+type AcceptProjectInvitationFunc func(*ProjectInvitation)
+
 func (i *ProjectInvitation) Accept() {
 	i.Status = InvitationStatusAccepted
 	i.UpdatedAt = time.Now()

--- a/service/project.go
+++ b/service/project.go
@@ -2,10 +2,10 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"release-manager/pkg/apierrors"
 	cryptox "release-manager/pkg/crypto"
-	"release-manager/pkg/dberrors"
 	"release-manager/service/model"
 
 	"github.com/google/uuid"
@@ -338,31 +338,56 @@ func (s *ProjectService) CancelInvitation(ctx context.Context, projectID, invita
 }
 
 func (s *ProjectService) AcceptInvitation(ctx context.Context, tkn cryptox.Token) error {
-	invitation, err := s.getPendingInvitationByToken(ctx, tkn)
+	// When accepting an invitation, two possible scenarios can happen:
+	// 1. User does not exist yet, in which case invitation is only accepted
+	//    When a user registers later, a project member will be created (PostgreSQL function handle_new_user() is triggered upon user creation)
+	//    Must be done via Postgres function because user registration is not controlled by this API
+	// 2. User already exists, in which case a project member is created and invitation is deleted
+	//
+	// To keep more logic in service, we first fetch the invitation to get invitation's email
+	// Then we check if user with given email exists
+	// First two steps could be done in one query, but it would require mixing entities from two different repositories
+	// Based on user existence we either accept the invitation or create a project member and delete the invitation
+	//
+	// There is one possible raise condition:
+	// 1. We check if user exists (and he does not)
+	// 2. We only accept the invitation
+	// But user would register between these two steps
+	// Resulting in a project member not being created for existing user
+	// The raise condition is handled by the PostgreSQL function check_accepted_invitations_for_registered_users()
+
+	invitation, err := s.repo.ReadPendingInvitationByHash(ctx, tkn.ToHash())
 	if err != nil {
-		return err
+		return fmt.Errorf("reading invitation by token hash: %w", err)
 	}
 
 	u, err := s.userGetter.GetByEmail(ctx, invitation.Email)
 	if err != nil && !apierrors.IsNotFoundError(err) {
-		return err
+		return fmt.Errorf("reading user by email: %w", err)
 	}
 
-	// User does not exist yet, just accept the invitation
-	// When a user registers, a project membership will be created;
-	// PostgreSQL function handle_new_user() is triggered upon user creation
+	// User does not exist yet
 	if apierrors.IsNotFoundError(err) {
-		invitation.Accept()
-		return s.repo.UpdateInvitation(ctx, invitation)
+		if err := s.repo.AcceptPendingInvitation(ctx, invitation.ID, func(i *model.ProjectInvitation) {
+			i.Accept()
+		}); err != nil {
+			return fmt.Errorf("accepting invitation: %w", err)
+		}
+
+		return nil
 	}
 
-	// User exists
 	member, err := model.NewProjectMember(u, invitation.ProjectID, invitation.ProjectRole)
 	if err != nil {
-		return err
+		return fmt.Errorf("creating project member object: %w", err)
 	}
 
-	return s.repo.CreateMember(ctx, member)
+	// Creates a project member and deletes the invitation
+	if err := s.repo.CreateMember(ctx, member); err != nil {
+		return fmt.Errorf("creating project member in repo: %w", err)
+	}
+
+	return nil
 }
 
 func (s *ProjectService) RejectInvitation(ctx context.Context, tkn cryptox.Token) error {
@@ -451,19 +476,6 @@ func (s *ProjectService) projectExists(ctx context.Context, projectID uuid.UUID)
 	}
 
 	return true, nil
-}
-
-func (s *ProjectService) getPendingInvitationByToken(ctx context.Context, tkn cryptox.Token) (model.ProjectInvitation, error) {
-	i, err := s.repo.ReadInvitationByTokenHashAndStatus(ctx, tkn.ToHash(), model.InvitationStatusPending)
-	if err != nil {
-		if dberrors.IsNotFoundError(err) {
-			return model.ProjectInvitation{}, apierrors.NewProjectInvitationNotFoundError().Wrap(err)
-		}
-
-		return model.ProjectInvitation{}, err
-	}
-
-	return i, nil
 }
 
 func (s *ProjectService) invitationExists(ctx context.Context, email string, projectID uuid.UUID) (bool, error) {

--- a/service/project.go
+++ b/service/project.go
@@ -349,12 +349,12 @@ func (s *ProjectService) AcceptInvitation(ctx context.Context, tkn cryptox.Token
 	// First two steps could be done in one query, but it would require mixing entities from two different repositories
 	// Based on user existence we either accept the invitation or create a project member and delete the invitation
 	//
-	// There is one possible raise condition:
+	// There is one possible race condition:
 	// 1. We check if user exists (and he does not)
 	// 2. We only accept the invitation
 	// But user would register between these two steps
 	// Resulting in a project member not being created for existing user
-	// The raise condition is handled by the PostgreSQL function check_accepted_invitations_for_registered_users()
+	// The race condition is handled by the PostgreSQL function check_accepted_invitations_for_registered_users()
 
 	invitation, err := s.repo.ReadPendingInvitationByHash(ctx, tkn.ToHash())
 	if err != nil {

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -987,35 +987,35 @@ func TestProjectService_AcceptInvitation(t *testing.T) {
 		{
 			name: "Unknown invitation",
 			mockSetup: func(user *svc.UserService, projectRepo *repo.ProjectRepository) {
-				projectRepo.On("ReadInvitationByTokenHashAndStatus", mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectInvitation{}, dberrors.NewNotFoundError())
+				projectRepo.On("ReadPendingInvitationByHash", mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectInvitation{}, apierrors.NewProjectInvitationNotFoundError())
 			},
 			wantErr: true,
 		},
 		{
 			name: "Success - invitation is accepted",
 			mockSetup: func(user *svc.UserService, projectRepo *repo.ProjectRepository) {
-				projectRepo.On("ReadInvitationByTokenHashAndStatus", mock.Anything, mock.Anything, mock.Anything).Return(
+				projectRepo.On("ReadPendingInvitationByHash", mock.Anything, mock.Anything, mock.Anything).Return(
 					model.ProjectInvitation{
 						Email: "test@test.tt", ProjectRole: model.ProjectRoleEditor, Status: model.InvitationStatusPending, ProjectID: uuid.New(),
 					},
 					nil,
 				)
 				user.On("GetByEmail", mock.Anything, mock.Anything).Return(model.User{}, apierrors.NewUserNotFoundError())
-				projectRepo.On("UpdateInvitation", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				projectRepo.On("AcceptPendingInvitation", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
 		},
 		{
 			name: "Success - project member is created",
 			mockSetup: func(user *svc.UserService, projectRepo *repo.ProjectRepository) {
-				projectRepo.On("ReadInvitationByTokenHashAndStatus", mock.Anything, mock.Anything, mock.Anything).Return(
+				projectRepo.On("ReadPendingInvitationByHash", mock.Anything, mock.Anything, mock.Anything).Return(
 					model.ProjectInvitation{
 						Email: "test@test.tt", ProjectRole: model.ProjectRoleEditor, Status: model.InvitationStatusPending, ProjectID: uuid.New(),
 					},
 					nil,
 				)
 				user.On("GetByEmail", mock.Anything, mock.Anything).Return(model.User{}, nil)
-				projectRepo.On("CreateMember", mock.Anything, mock.Anything).Return(nil)
+				projectRepo.On("CreateMember", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
 		},

--- a/service/service.go
+++ b/service/service.go
@@ -27,11 +27,11 @@ type projectRepository interface {
 
 	CreateInvitation(ctx context.Context, i model.ProjectInvitation) error
 	ListInvitationsForProject(ctx context.Context, projectID uuid.UUID) ([]model.ProjectInvitation, error)
-	ReadInvitationByTokenHashAndStatus(ctx context.Context, hash cryptox.Hash, status model.ProjectInvitationStatus) (model.ProjectInvitation, error)
 	ReadInvitationByEmail(ctx context.Context, email string, projectID uuid.UUID) (model.ProjectInvitation, error)
+	ReadPendingInvitationByHash(ctx context.Context, hash cryptox.Hash) (model.ProjectInvitation, error)
 	DeleteInvitation(ctx context.Context, projectID, invitationID uuid.UUID) error
 	DeleteInvitationByTokenHashAndStatus(ctx context.Context, hash cryptox.Hash, status model.ProjectInvitationStatus) error
-	UpdateInvitation(ctx context.Context, i model.ProjectInvitation) error
+	AcceptPendingInvitation(ctx context.Context, invitationID uuid.UUID, fn model.AcceptProjectInvitationFunc) error
 
 	CreateMember(ctx context.Context, member model.ProjectMember) error
 	ListMembersForProject(ctx context.Context, projectID uuid.UUID) ([]model.ProjectMember, error)

--- a/supabase/migrations/20240504173609_check_accepted_invitations_for_registered_users.sql
+++ b/supabase/migrations/20240504173609_check_accepted_invitations_for_registered_users.sql
@@ -2,7 +2,7 @@
 -- this race condition can happen in ProjectService -> AcceptInvitation(), scenario:
 -- 1. service checks if user exists, user does not exist yet
 -- 2. service accepts invitation, status is updated to 'accepted_awaiting_registration'
--- but the first and second steps are not executed in the same transaction, so a user with the same email can be created in the meantime
+-- user registers between 1 and 2
 -- very unlikely, but still possible
 
 CREATE OR REPLACE FUNCTION check_accepted_invitations_for_registered_users()


### PR DESCRIPTION
Just general note:

These are the last few PRs for switching from the Supabase client to the DB pool :tada:. 

Once the final one is merged, I will do one more clean-up PR where I remove all unused code and unify the naming, as there may still be some inconsistencies.