### PR TITLE
feat: add private getProject svc func

### DIFF
--- a/service/project.go
+++ b/service/project.go
@@ -68,12 +68,7 @@ func (s *ProjectService) CreateProject(ctx context.Context, c model.CreateProjec
 func (s *ProjectService) GetProject(ctx context.Context, projectID uuid.UUID, authUserID uuid.UUID) (model.Project, error) {
 	// TODO add project member authorization
 
-	p, err := s.repo.ReadProject(ctx, projectID)
-	if err != nil {
-		return model.Project{}, err
-	}
-
-	return p, nil
+	return s.getProject(ctx, projectID)
 }
 
 func (s *ProjectService) ListProjects(ctx context.Context, authUserID uuid.UUID) ([]model.Project, error) {
@@ -438,6 +433,15 @@ func (s *ProjectService) UpdateMemberRole(ctx context.Context, newRole model.Pro
 	}
 
 	return m, nil
+}
+
+func (s *ProjectService) getProject(ctx context.Context, projectID uuid.UUID) (model.Project, error) {
+	p, err := s.repo.ReadProject(ctx, projectID)
+	if err != nil {
+		return model.Project{}, err
+	}
+
+	return p, nil
 }
 
 func (s *ProjectService) projectExists(ctx context.Context, projectID uuid.UUID) (bool, error) {


### PR DESCRIPTION
Once all repo refactoring PRs are merged, I want to add authorization to all service functions (the `auth guard` is ready).

Currently, all functions in `ProjectService` that need to get a project call `s.GetProject(ctx context.Context, projectID uuid.UUID, authUserID uuid.UUID)`.

This means that each project service function would:
- perform an authorization check within its own function.
- then call `s.GetProject`, which repeats the authorization check inside `GetProject`.

I think if both functions are inside `ProjectService`, double authorization check should be avoided. Therefore private method `s.getProject(ctx context.Context, projectID uuid.UUID)` is being added.

Once this is merged, `s.getProject` will be used in all appropriate places.

-----

On the other hand, if different service needs to get a project, I think it is good to call `s.GetProject(ctx context.Context, projectID uuid.UUID, authUserID uuid.UUID)`, because the project service should control who can access the project.