### PR TITLE
feat(github client): add funcionality for creating a github release

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -29,13 +29,10 @@ func (c *Client) ReadTagsForRepository(ctx context.Context, tkn string, repoURL 
 		return nil, apierrors.NewGithubRepositoryInvalidURL().Wrap(err).WithMessage(err.Error())
 	}
 
-	// GitHub client is created in the function because it needs to be authenticated with a token (that is passed as an argument)
-	client := github.NewClient(nil).WithAuthToken(tkn)
-
 	// Up to 100 tags can be fetched per page
 	// If the number of pages is not specified in the list options, only one page will be fetched
 	// https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
-	t, _, err := client.Repositories.ListTags(
+	t, _, err := c.getGithubClient(tkn).Repositories.ListTags(
 		ctx,
 		repo.OwnerSlug,
 		repo.RepositorySlug,
@@ -58,4 +55,38 @@ func (c *Client) ReadTagsForRepository(ctx context.Context, tkn string, repoURL 
 	}
 
 	return model.ToSvcGitTags(t), nil
+}
+
+func (c *Client) CreateRelease(
+	ctx context.Context,
+	tkn string,
+	repoURL url.URL,
+	input svcmodel.CreateReleaseInput,
+) (svcmodel.GithubRelease, error) {
+	repo, err := model.ToGithubRepo(repoURL)
+	if err != nil {
+		return svcmodel.GithubRelease{}, apierrors.NewGithubRepositoryInvalidURL().Wrap(err).WithMessage(err.Error())
+	}
+
+	// Creates a new release
+	// Docs: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release
+	//
+	// TagName is the name of the tag to link the release to
+	// Name is the name of the release
+	// Body is the description of the release
+	rls, _, err := c.getGithubClient(tkn).Repositories.CreateRelease(ctx, repo.OwnerSlug, repo.RepositorySlug, &github.RepositoryRelease{
+		TagName: &input.GitTagName,
+		Name:    &input.ReleaseTitle,
+		Body:    &input.ReleaseNotes,
+	})
+	if err != nil {
+		// TODO translate to service error if this function is not executed asynchronously
+		return svcmodel.GithubRelease{}, err
+	}
+
+	return model.ToSvcGithubRelease(rls)
+}
+
+func (c *Client) getGithubClient(tkn string) *github.Client {
+	return github.NewClient(nil).WithAuthToken(tkn)
 }

--- a/github/model/model.go
+++ b/github/model/model.go
@@ -50,3 +50,20 @@ func ToSvcGitTags(tags []*github.RepositoryTag) []svcmodel.GitTag {
 
 	return t
 }
+
+func ToSvcGithubRelease(release *github.RepositoryRelease) (svcmodel.GithubRelease, error) {
+	u, err := url.Parse(release.GetHTMLURL())
+	if err != nil {
+		return svcmodel.GithubRelease{}, err
+	}
+
+	return svcmodel.GithubRelease{
+		ID:          release.GetID(),
+		Name:        release.GetName(),
+		Body:        release.GetBody(),
+		HTMLURL:     *u,
+		TagName:     release.GetTagName(),
+		CreatedAt:   release.CreatedAt.Time,
+		PublishedAt: release.PublishedAt.Time,
+	}, nil
+}

--- a/service/model/release.go
+++ b/service/model/release.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"errors"
+	"net/url"
 	"time"
 
 	"github.com/google/uuid"
@@ -14,6 +15,7 @@ var (
 type CreateReleaseInput struct {
 	ReleaseTitle string
 	ReleaseNotes string
+	GitTagName   string // used for linking the release with a specific point in a git repository, TODO make this field required
 }
 
 type Release struct {
@@ -78,4 +80,14 @@ func NewReleaseNotification(p Project, r Release) ReleaseNotification {
 	}
 
 	return n
+}
+
+type GithubRelease struct {
+	ID          int64 // GitHub release ID
+	Name        string
+	Body        string
+	TagName     string  // Git tag associated with the release
+	HTMLURL     url.URL // URL to the release page on GitHub
+	CreatedAt   time.Time
+	PublishedAt time.Time
 }


### PR DESCRIPTION
When user creates a new release, **existing*** git tag must be provided in order to link release to source code. Once these PR are merged, release service will:
- check if provided git tag actually exists (https://github.com/jan-zabloudil/release-manager/pull/87)
- check if provided git tag is associated with github release (https://github.com/jan-zabloudil/release-manager/pull/88)
- create a github release (if tag is not associated with one yet) and user allows github release creation (this PR)

---

*) In the first MVP version, only existing git tags will be supported. Later, the functionality will be extended to allow the use of new git tags as well (`ReleaseManager` would create a new git tag).
