### PR TITLE
feat(github client): add functionality for reading a git tag

### DIFF
--- a/pkg/apierrors/apierrors.go
+++ b/pkg/apierrors/apierrors.go
@@ -33,6 +33,7 @@ var (
 	errCodeReleaseUnprocessable                    = "ERR_RELEASE_UNPROCESSABLE"
 	errCodeReleaseNotFound                         = "ERR_RELEASE_NOT_FOUND"
 	errCodeSlackIntegrationNotEnabled              = "ERR_SLACK_INTEGRATION_NOT_ENABLED"
+	errCodeGitTagNotFound                          = "ERR_GIT_TAG_NOT_FOUND"
 )
 
 type APIError struct {
@@ -240,6 +241,13 @@ func NewSlackIntegrationNotEnabledError() *APIError {
 	}
 }
 
+func NewGitTagNotFoundError() *APIError {
+	return &APIError{
+		Code:    errCodeGitTagNotFound,
+		Message: "Git tag not found",
+	}
+}
+
 func IsErrorWithCode(err error, code string) bool {
 	var apiErr *APIError
 	if errors.As(err, &apiErr) {
@@ -260,7 +268,8 @@ func IsNotFoundError(err error) bool {
 		IsErrorWithCode(err, errCodeProjectMemberNotFound) ||
 		IsErrorWithCode(err, errCodeGithubIntegrationNotEnabled) ||
 		IsErrorWithCode(err, errCodeGithubRepositoryInvalidURL) ||
-		IsErrorWithCode(err, errCodeReleaseNotFound)
+		IsErrorWithCode(err, errCodeReleaseNotFound) ||
+		IsErrorWithCode(err, errCodeGitTagNotFound)
 }
 
 func IsUnprocessableModelError(err error) bool {


### PR DESCRIPTION
When user creates a new release, **existing*** git tag must be provided in order to link release to source code. Once these PR are merged, release service will:
- check if provided git tag actually exists (this PR)
- check if provided git tag is associated with github release (https://github.com/jan-zabloudil/release-manager/pull/88)
- create a github release (if tag is not associated with one yet) and user allows github release creation (https://github.com/jan-zabloudil/release-manager/pull/86)

---

*) In the first MVP version, only existing git tags will be supported. Later, the functionality will be extended to allow the use of new git tags as well (`ReleaseManager` would create a new git tag).