### PR TITLE
feat(github client): add functionality for reading a github release by tag

### DIFF
--- a/pkg/apierrors/apierrors.go
+++ b/pkg/apierrors/apierrors.go
@@ -34,6 +34,7 @@ var (
 	errCodeReleaseNotFound                         = "ERR_RELEASE_NOT_FOUND"
 	errCodeSlackIntegrationNotEnabled              = "ERR_SLACK_INTEGRATION_NOT_ENABLED"
 	errCodeGitTagNotFound                          = "ERR_GIT_TAG_NOT_FOUND"
+	errCodeGithubReleaseNotFound                   = "ERR_GITHUB_RELEASE_NOT_FOUND"
 )
 
 type APIError struct {
@@ -248,6 +249,13 @@ func NewGitTagNotFoundError() *APIError {
 	}
 }
 
+func NewGithubReleaseNotFoundError() *APIError {
+	return &APIError{
+		Code:    errCodeGithubReleaseNotFound,
+		Message: "Github release not found",
+	}
+}
+
 func IsErrorWithCode(err error, code string) bool {
 	var apiErr *APIError
 	if errors.As(err, &apiErr) {
@@ -269,7 +277,8 @@ func IsNotFoundError(err error) bool {
 		IsErrorWithCode(err, errCodeGithubIntegrationNotEnabled) ||
 		IsErrorWithCode(err, errCodeGithubRepositoryInvalidURL) ||
 		IsErrorWithCode(err, errCodeReleaseNotFound) ||
-		IsErrorWithCode(err, errCodeGitTagNotFound)
+		IsErrorWithCode(err, errCodeGitTagNotFound) ||
+		IsErrorWithCode(err, errCodeGithubReleaseNotFound)
 }
 
 func IsUnprocessableModelError(err error) bool {


### PR DESCRIPTION
When user creates a new release, **existing*** git tag must be provided in order to link release to source code. Once these PR are merged, release service will:
- check if provided git tag actually exists (https://github.com/jan-zabloudil/release-manager/pull/87)
- check if provided git tag is associated with github release (this PR)
- create a github release (if tag is not associated with one yet) and user allows github release creation (https://github.com/jan-zabloudil/release-manager/pull/86)

---

*) In the first MVP version, only existing git tags will be supported. Later, the functionality will be extended to allow the use of new git tags as well (`ReleaseManager` would create a new git tag).