### PR TITLE
feat: add git tag to release service model

### DIFF
--- a/github/model/model.go
+++ b/github/model/model.go
@@ -81,20 +81,3 @@ func ToSvcGitTags(tags []*github.RepositoryTag) []svcmodel.GitTag {
 
 	return t
 }
-
-func ToSvcGithubRelease(release *github.RepositoryRelease) (svcmodel.GithubRelease, error) {
-	u, err := url.Parse(release.GetHTMLURL())
-	if err != nil {
-		return svcmodel.GithubRelease{}, err
-	}
-
-	return svcmodel.GithubRelease{
-		ID:          release.GetID(),
-		Name:        release.GetName(),
-		Body:        release.GetBody(),
-		HTMLURL:     *u,
-		TagName:     release.GetTagName(),
-		CreatedAt:   release.CreatedAt.Time,
-		PublishedAt: release.PublishedAt.Time,
-	}, nil
-}

--- a/service/model/release.go
+++ b/service/model/release.go
@@ -33,7 +33,8 @@ type Release struct {
 	AuthorUserID uuid.UUID
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
-	// TODO add source code link
+	GitTagName   string
+	GitTagURL    url.URL
 }
 
 func NewRelease(input CreateReleaseInput, projectID, authorUserID uuid.UUID) (Release, error) {
@@ -106,14 +107,4 @@ func NewReleaseNotification(p Project, r Release) ReleaseNotification {
 	}
 
 	return n
-}
-
-type GithubRelease struct {
-	ID          int64 // GitHub release ID
-	Name        string
-	Body        string
-	TagName     string  // Git tag associated with the release
-	HTMLURL     url.URL // URL to the release page on GitHub
-	CreatedAt   time.Time
-	PublishedAt time.Time
 }


### PR DESCRIPTION
**feat: add git tag to release service model**
- Added `GitTagName` and `GitTagURL` to `Release` service model. (for now just added to service model, more to come in following PRs)
- `GithubRelease` struct removed because we dont need it.

**refactor(github-client): remove release functions:**
- `CreateRelease` and `ReadReleaseByTag` in github client removed, it will be refactored in https://github.com/jan-zabloudil/release-manager/pull/120 
- I removed them because they were requiring `svcmodel.GithubRelease` that is being deleted in this PR


