### PR TITLE
feat: add dedicated endpoint for setting github repository for a project

### DIFF
--- a/github/mock/client.go
+++ b/github/mock/client.go
@@ -18,7 +18,7 @@ func (c *Client) ReadTagsForRepository(ctx context.Context, tkn string, repoURL 
 	return args.Get(0).([]svcmodel.GitTag), args.Error(1)
 }
 
-func (c *Client) GetGithubRepoFromRawURL(rawURL string) (svcmodel.GithubRepo, error) {
-	args := c.Called(rawURL)
+func (c *Client) ReadRepository(ctx context.Context, tkn string, rawRepoURL string) (svcmodel.GithubRepo, error) {
+	args := c.Called(ctx, tkn, rawRepoURL)
 	return args.Get(0).(svcmodel.GithubRepo), args.Error(1)
 }

--- a/github/model/model.go
+++ b/github/model/model.go
@@ -29,10 +29,10 @@ type GithubRepo struct {
 	RepositorySlug string
 }
 
-func ToSvcGithubRepo(rawURL string) (svcmodel.GithubRepo, error) {
+func ParseGithubRepoURL(rawURL string) (ownerSlug, repoSlug string, err error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return svcmodel.GithubRepo{}, err
+		return "", "", err
 	}
 
 	// GitHub repo URL format: https://github.com/owner/repo,
@@ -41,18 +41,14 @@ func ToSvcGithubRepo(rawURL string) (svcmodel.GithubRepo, error) {
 	slugs := strings.Split(path, "/")
 
 	if len(slugs) != expectedGithubRepositoryURLSlugCount {
-		return svcmodel.GithubRepo{}, errInvalidGithubRepoURLPath
+		return "", "", errInvalidGithubRepoURLPath
 	}
 
 	if slugs[0] == "" || slugs[1] == "" {
-		return svcmodel.GithubRepo{}, errInvalidGithubRepoURLPath
+		return "", "", errInvalidGithubRepoURLPath
 	}
 
-	return svcmodel.GithubRepo{
-		HTMLURL:   *u,
-		OwnerSlug: slugs[0],
-		RepoSlug:  slugs[1],
-	}, nil
+	return slugs[0], slugs[1], nil
 }
 
 func ToGithubRepo(u url.URL) (GithubRepo, error) {

--- a/repository/query/scripts/update_project.sql
+++ b/repository/query/scripts/update_project.sql
@@ -3,6 +3,9 @@ SET
     name = @name,
     slack_channel_id = @slackChannelID,
     release_notification_config = @releaseNotificationConfig,
-    github_repository_url = @githubRepositoryURL,
+    github_repository_url = @githubRepositoryURL, -- TODO remove
+    github_owner_slug = @githubOwnerSlug,
+    github_repo_slug = @githubRepoSlug,
+    github_repo_url = @githubRepoURL,
     updated_at = @updatedAt
 WHERE id = @id

--- a/service/model/project.go
+++ b/service/model/project.go
@@ -21,14 +21,14 @@ type Project struct {
 	Name                      string
 	SlackChannelID            string
 	ReleaseNotificationConfig ReleaseNotificationConfig
-	GithubRepositoryURL       url.URL
+	GithubRepositoryURL       url.URL // TODO remove this field
 	GithubRepo                *GithubRepo
 	CreatedAt                 time.Time
 	UpdatedAt                 time.Time
 }
 
 type GithubRepo struct {
-	HTMLURL   url.URL
+	URL       url.URL
 	OwnerSlug string
 	RepoSlug  string
 }
@@ -37,14 +37,14 @@ type CreateProjectInput struct {
 	Name                      string
 	SlackChannelID            string
 	ReleaseNotificationConfig ReleaseNotificationConfig
-	GithubRepositoryRawURL    string
+	GithubRepositoryRawURL    string // TODO remove this field
 }
 
 type UpdateProjectInput struct {
 	Name                            *string
 	SlackChannelID                  *string
 	ReleaseNotificationConfigUpdate UpdateReleaseNotificationConfigInput
-	GithubRepositoryRawURL          *string
+	GithubRepositoryRawURL          *string // TODO remove this field
 }
 
 type ReleaseNotificationConfig struct {
@@ -87,6 +87,11 @@ func NewProject(c CreateProjectInput) (Project, error) {
 	}
 
 	return p, nil
+}
+
+func (p *Project) SetGithubRepo(repo *GithubRepo) {
+	p.GithubRepo = repo
+	p.UpdatedAt = time.Now()
 }
 
 type UpdateProjectFunc func(p Project) (Project, error)

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -35,7 +35,6 @@ func TestProjectService_CreateProject(t *testing.T) {
 			mockSetup: func(auth *svc.AuthorizeService, settings *svc.SettingsService, user *svc.UserService, github *githubmock.Client, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				settings.On("GetDefaultReleaseMessage", mock.Anything).Return("message", nil)
-				github.On("GetGithubRepoFromRawURL", mock.Anything).Return(model.GithubRepo{}, nil)
 				user.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(model.User{}, nil)
 				projectRepo.On("CreateProjectWithOwner", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
@@ -50,7 +49,6 @@ func TestProjectService_CreateProject(t *testing.T) {
 			},
 			mockSetup: func(auth *svc.AuthorizeService, settings *svc.SettingsService, user *svc.UserService, github *githubmock.Client, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
-				github.On("GetGithubRepoFromRawURL", mock.Anything).Return(model.GithubRepo{}, nil)
 				user.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(model.User{}, nil)
 				projectRepo.On("CreateProjectWithOwner", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
@@ -65,7 +63,6 @@ func TestProjectService_CreateProject(t *testing.T) {
 			},
 			mockSetup: func(auth *svc.AuthorizeService, settings *svc.SettingsService, user *svc.UserService, github *githubmock.Client, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
-				github.On("GetGithubRepoFromRawURL", mock.Anything).Return(model.GithubRepo{}, nil)
 			},
 			wantErr: true,
 		},
@@ -78,7 +75,6 @@ func TestProjectService_CreateProject(t *testing.T) {
 			},
 			mockSetup: func(auth *svc.AuthorizeService, settings *svc.SettingsService, user *svc.UserService, github *githubmock.Client, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
-				github.On("GetGithubRepoFromRawURL", mock.Anything).Return(model.GithubRepo{}, nil)
 			},
 			wantErr: true,
 		},
@@ -92,7 +88,6 @@ func TestProjectService_CreateProject(t *testing.T) {
 			},
 			mockSetup: func(auth *svc.AuthorizeService, settings *svc.SettingsService, user *svc.UserService, github *githubmock.Client, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
-				github.On("GetGithubRepoFromRawURL", mock.Anything).Return(model.GithubRepo{}, nil)
 			},
 			wantErr: true,
 		},

--- a/service/service.go
+++ b/service/service.go
@@ -83,7 +83,7 @@ type projectGetter interface {
 }
 
 type githubManager interface {
-	GetGithubRepoFromRawURL(rawURL string) (model.GithubRepo, error)
+	ReadRepository(ctx context.Context, token, rawRepoURL string) (model.GithubRepo, error)
 	ReadTagsForRepository(ctx context.Context, token string, repoURL url.URL) ([]model.GitTag, error)
 }
 

--- a/supabase/migrations/20240427062850_projects_github_repository.sql
+++ b/supabase/migrations/20240427062850_projects_github_repository.sql
@@ -1,2 +1,5 @@
 ALTER TABLE public.projects
-ADD COLUMN github_repository_url TEXT;
+ADD COLUMN github_repository_url TEXT, -- todo remove
+ADD COLUMN github_owner_slug TEXT,
+ADD COLUMN github_repo_slug TEXT,
+ADD COLUMN github_repo_url TEXT;

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -16,6 +16,7 @@ type projectService interface {
 	ListProjects(ctx context.Context, authUserID uuid.UUID) ([]svcmodel.Project, error)
 	UpdateProject(ctx context.Context, u svcmodel.UpdateProjectInput, projectID, authUserID uuid.UUID) (svcmodel.Project, error)
 	DeleteProject(ctx context.Context, projectID uuid.UUID, authUserID uuid.UUID) error
+	SetGithubRepoForProject(ctx context.Context, rawRepoURL string, projectID uuid.UUID, authUserID uuid.UUID) error
 
 	CreateEnvironment(ctx context.Context, c svcmodel.CreateEnvironmentInput, authUserID uuid.UUID) (svcmodel.Environment, error)
 	GetEnvironment(ctx context.Context, projectID, envID, authUserID uuid.UUID) (svcmodel.Environment, error)

--- a/transport/handler/project.go
+++ b/transport/handler/project.go
@@ -92,3 +92,23 @@ func (h *Handler) listGithubRepositoryTags(w http.ResponseWriter, r *http.Reques
 
 	util.WriteJSONResponse(w, http.StatusOK, model.ToGitTags(t))
 }
+
+func (h *Handler) setGithubRepoForProject(w http.ResponseWriter, r *http.Request) {
+	var input model.SetProjectGithubRepoInput
+	if err := util.UnmarshalRequest(r, &input); err != nil {
+		util.WriteResponseError(w, resperrors.NewBadRequestError().Wrap(err).WithMessage(err.Error()))
+		return
+	}
+
+	if err := h.ProjectSvc.SetGithubRepoForProject(
+		r.Context(),
+		input.RawRepoURL,
+		util.ContextProjectID(r),
+		util.ContextAuthUserID(r),
+	); err != nil {
+		util.WriteResponseError(w, resperrors.ToError(err))
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/transport/handler/routes.go
+++ b/transport/handler/routes.go
@@ -59,7 +59,10 @@ func (h *Handler) setupRoutes() {
 					r.Patch("/", middleware.RequireAuthUser(h.updateMemberRole))
 				})
 			})
-			r.Get("/repository/tags", middleware.RequireAuthUser(h.listGithubRepositoryTags))
+			r.Route("/github-repository", func(r chi.Router) {
+				r.Post("/", middleware.RequireAuthUser(h.setGithubRepoForProject))
+				r.Get("/tags", middleware.RequireAuthUser(h.listGithubRepositoryTags))
+			})
 			r.Route("/releases", func(r chi.Router) {
 				r.Get("/", middleware.RequireAuthUser(h.listReleases))
 				r.Post("/", middleware.RequireAuthUser(h.createRelease))

--- a/transport/model/project.go
+++ b/transport/model/project.go
@@ -12,14 +12,18 @@ type CreateProjectInput struct {
 	Name                      string                    `json:"name"`
 	SlackChannelID            string                    `json:"slack_channel_id"`
 	ReleaseNotificationConfig ReleaseNotificationConfig `json:"release_notification_config"`
-	GithubRepositoryURL       string                    `json:"github_repository_url"`
+	GithubRepositoryURL       string                    `json:"github_repository_url"` // TODO remove
 }
 
 type UpdateProjectInput struct {
 	Name                      *string                              `json:"name"`
 	SlackChannelID            *string                              `json:"slack_channel_id"`
 	ReleaseNotificationConfig UpdateReleaseNotificationConfigInput `json:"release_notification_config"`
-	GithubRepositoryURL       *string                              `json:"github_repository_url"`
+	GithubRepositoryURL       *string                              `json:"github_repository_url"` // TODO remove
+}
+
+type SetProjectGithubRepoInput struct {
+	RawRepoURL string `json:"github_repo_url"`
 }
 
 type Project struct {
@@ -27,7 +31,7 @@ type Project struct {
 	Name                      string                    `json:"name"`
 	SlackChannelID            string                    `json:"slack_channel_id"`
 	ReleaseNotificationConfig ReleaseNotificationConfig `json:"release_notification_config"`
-	GithubRepository          string                    `json:"github_repository_url"`
+	GithubRepository          string                    `json:"github_repository_url"` // TODO remove this field
 	CreatedAt                 time.Time                 `json:"created_at"`
 	UpdatedAt                 time.Time                 `json:"updated_at"`
 }


### PR DESCRIPTION
I realized it won't take much work to prepare a dedicated endpoint for setting a GitHub repository for a project. This will make the overall implementation more solid.

I have added a dedicated endpoint to serve this purpose:

`/projects/{id}/github-repository` (singular, as you can only set one repository)

The service calls a GitHub client that verifies your access to the specified GitHub repository (and that the repository actually exists). This is another step towards the GitHub refactoring.

The final step will be to create a separate table for GitHub repositories. For now, I have added the fields to the project service model.

I have also kept the current `project.GithubRepositoryURL` field. I will remove it in a subsequent PR once this one is merged to keep the PR size manageable.

The flow is as follows:
- You create your project (without entering github repo url); the transport project model does not contain the GitHub repository URL.
- You have a dedicated endpoint for setting the connection to the GitHub repository.
- I have implemented only the POST endpoint. If you agree with the implementation, I will also add the GET endpoint.

---

Once this PR is merged, I will also update github client functions (such as reading git tags, creating github release etc.) to accept `svcmodel.GithubRepo` instead of repoURL.

---

If you approve, I wll also add tests.