### PR TITLE
feat(release svc): SendReleaseNotification sends slack message synchronously

### DIFF
--- a/service/release.go
+++ b/service/release.go
@@ -163,8 +163,9 @@ func (s *ReleaseService) SendReleaseNotification(ctx context.Context, projectID,
 		return fmt.Errorf("getting slack token: %w", err)
 	}
 
-	// TODO use synchronous notification sending
-	s.slackNotifier.SendReleaseNotificationAsync(ctx, tkn, p.SlackChannelID, model.NewReleaseNotification(p, rls))
+	if err := s.slackNotifier.SendReleaseNotification(ctx, tkn, p.SlackChannelID, model.NewReleaseNotification(p, rls)); err != nil {
+		return fmt.Errorf("sending slack notification: %w", err)
+	}
 
 	return nil
 }

--- a/service/release_test.go
+++ b/service/release_test.go
@@ -399,7 +399,7 @@ func TestReleaseService_SendReleaseNotification(t *testing.T) {
 					SlackChannelID: "channel",
 				}, nil)
 				settingsSvc.On("GetSlackToken", mock.Anything).Return("token", nil)
-				slackClient.On("SendReleaseNotificationAsync", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+				slackClient.On("SendReleaseNotification", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Once this one is merged, I will also remove the async function. We agreed on the following workflow:

1. The user creates the release. (no slack message sending together with release creation)
2. Once the release is created, the user can "populate changes to GitHub," "send a Slack notification," and later on, deploy the release etc.

