### PR TITLE
feat(transport): listen for git tag deleted webhook event

### DIFF
--- a/transport/model/webhook.go
+++ b/transport/model/webhook.go
@@ -1,12 +1,11 @@
 package model
 
-type GithubReleaseWebhookInput struct {
-	Action  string `json:"action" required:"true"`
-	Release struct {
-		Name string `json:"name" required:"true"`
-		Body string `json:"body"`
-	} `json:"release"`
-	Repo struct {
+type GithubRefWebhookInput struct {
+	// Ref is the name of the reference (tag, branch, etc.)
+	Ref string `json:"ref" required:"true"`
+	// RefType is the type of the reference (e.g. "branch" or "tag")
+	RefType string `json:"ref_type" required:"true"`
+	Repo    struct {
 		// Owner and repository slug of the GitHub repository separated by a slash
 		// (e.g. "owner/repo")
 		Slugs string `json:"full_name"`

--- a/transport/util/request.go
+++ b/transport/util/request.go
@@ -12,6 +12,9 @@ import (
 
 const (
 	SignatureHeader = "X-Hub-Signature-256"
+	// GithubHookEvent is the header key for the GitHub webhook event type.
+	// Docs: https://docs.github.com/en/webhooks/webhook-events-and-payloads
+	GithubHookEvent = "X-GitHub-Event"
 )
 
 func GetUUIDFromURL(r *http.Request, key string) (uuid.UUID, error) {


### PR DESCRIPTION
After discussion the only webhook event we need to "listen" to is tag deletion event.