### PR TITLE
feat(github-client): add functions for upserting and deleting github releases

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -105,12 +105,7 @@ func (c *Client) ReadTagsForRepository(ctx context.Context, tkn string, repoURL 
 	return model.ToSvcGitTags(t), nil
 }
 
-func (c *Client) ReadTagByName(ctx context.Context, tkn string, repoURL url.URL, tagName string) (svcmodel.GitTag, error) {
-	repo, err := model.ToGithubRepo(repoURL)
-	if err != nil {
-		return svcmodel.GitTag{}, svcerrors.NewGithubRepositoryInvalidURL().Wrap(err).WithMessage(err.Error())
-	}
-
+func (c *Client) ReadTagByName(ctx context.Context, tkn string, repo svcmodel.GithubRepo, tagName string) (svcmodel.GitTag, error) {
 	// Git tag can be fetched only by its SHA, using GET /repos/{owner}/{repo}/git/tags/{tag_sha}
 	// Another limitation is that only annotated tags can be fetched by /repos/{owner}/{repo}/git/tags/{tag_sha}
 	// Because lightweight tags do not have their own SHA, they only reference a commit
@@ -118,10 +113,10 @@ func (c *Client) ReadTagByName(ctx context.Context, tkn string, repoURL url.URL,
 	//
 	// So in order to check if a tag exists by name (both lightweights and annotated tags), GET /repos/{owner}/{repo}/git/ref/{ref} is used
 	// Docs https://docs.github.com/rest/git/refs#get-a-reference
-	_, _, err = c.getGithubClient(tkn).Git.GetRef(
+	_, _, err := c.getGithubClient(tkn).Git.GetRef(
 		ctx,
 		repo.OwnerSlug,
-		repo.RepositorySlug,
+		repo.RepoSlug,
 		fmt.Sprintf("tags/%s", tagName),
 	)
 	if err != nil {

--- a/github/client.go
+++ b/github/client.go
@@ -35,10 +35,10 @@ func NewClient() *Client {
 	return &Client{}
 }
 
-func (c *Client) ReadRepository(ctx context.Context, tkn string, rawRepoURL string) (svcmodel.GithubRepo, error) {
+func (c *Client) ReadRepo(ctx context.Context, tkn string, rawRepoURL string) (svcmodel.GithubRepo, error) {
 	ownerSlug, repoSlug, err := model.ParseGithubRepoURL(rawRepoURL)
 	if err != nil {
-		return svcmodel.GithubRepo{}, svcerrors.NewGithubRepositoryInvalidURL().Wrap(err).WithMessage(err.Error())
+		return svcmodel.GithubRepo{}, svcerrors.NewGithubRepoInvalidURL().Wrap(err).WithMessage(err.Error())
 	}
 
 	// Docs: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
@@ -52,7 +52,7 @@ func (c *Client) ReadRepository(ctx context.Context, tkn string, rawRepoURL stri
 			case http.StatusForbidden:
 				return svcmodel.GithubRepo{}, svcerrors.NewGithubClientForbiddenError().Wrap(err)
 			case http.StatusNotFound:
-				return svcmodel.GithubRepo{}, svcerrors.NewGithubRepositoryNotFoundError().Wrap(err)
+				return svcmodel.GithubRepo{}, svcerrors.NewGithubRepoNotFoundError().Wrap(err)
 			}
 		}
 
@@ -61,7 +61,7 @@ func (c *Client) ReadRepository(ctx context.Context, tkn string, rawRepoURL stri
 
 	u, err := url.Parse(repo.GetHTMLURL())
 	if err != nil {
-		return svcmodel.GithubRepo{}, fmt.Errorf("failed to parse repository URL: %w", err)
+		return svcmodel.GithubRepo{}, fmt.Errorf("failed to parse repo URL: %w", err)
 	}
 
 	return svcmodel.GithubRepo{
@@ -71,10 +71,10 @@ func (c *Client) ReadRepository(ctx context.Context, tkn string, rawRepoURL stri
 	}, nil
 }
 
-func (c *Client) ReadTagsForRepository(ctx context.Context, tkn string, repoURL url.URL) ([]svcmodel.GitTag, error) {
+func (c *Client) ReadTagsForRepo(ctx context.Context, tkn string, repoURL url.URL) ([]svcmodel.GitTag, error) {
 	repo, err := model.ToGithubRepo(repoURL)
 	if err != nil {
-		return nil, svcerrors.NewGithubRepositoryInvalidURL().Wrap(err).WithMessage(err.Error())
+		return nil, svcerrors.NewGithubRepoInvalidURL().Wrap(err).WithMessage(err.Error())
 	}
 
 	// Up to 100 tags can be fetched per page
@@ -95,7 +95,7 @@ func (c *Client) ReadTagsForRepository(ctx context.Context, tkn string, repoURL 
 			case http.StatusForbidden:
 				return nil, svcerrors.NewGithubClientForbiddenError().Wrap(err)
 			case http.StatusNotFound:
-				return nil, svcerrors.NewGithubRepositoryNotFoundError().Wrap(err)
+				return nil, svcerrors.NewGithubRepoNotFoundError().Wrap(err)
 			}
 		}
 

--- a/github/client.go
+++ b/github/client.go
@@ -16,6 +16,17 @@ import (
 
 const (
 	tagsToFetch = 100
+
+	// GitHub API error codes
+	errCodeAlreadyExists = "already_exists"
+
+	// GitHub API error fields
+	gitTagNameField = "tag_name"
+)
+
+var (
+	errGithubReleaseNotFound      = errors.New("github release not found")
+	errGithubReleaseAlreadyExists = errors.New("github release already exists")
 )
 
 type Client struct{}
@@ -123,6 +134,129 @@ func (c *Client) ReadTagByName(ctx context.Context, tkn string, repoURL url.URL,
 	}
 
 	return svcmodel.GitTag{Name: tagName}, nil
+}
+
+func (c *Client) UpsertRelease(ctx context.Context, tkn string, repo svcmodel.GithubRepo, rls svcmodel.Release) error {
+	err := c.createRelease(ctx, tkn, repo, rls)
+	if err != nil {
+		if errors.Is(err, errGithubReleaseAlreadyExists) {
+			err = c.updateRelease(ctx, tkn, repo, rls)
+			if err != nil {
+				return fmt.Errorf("failed to update release: %w", err)
+			}
+		}
+
+		return fmt.Errorf("failed to create release: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) DeleteRelease(ctx context.Context, tkn string, repo svcmodel.GithubRepo, rls svcmodel.Release) error {
+	// Release can be deleted only by release ID
+	// Therefore I need to get release ID first
+	id, err := c.getReleaseIDByTag(ctx, tkn, repo, rls.GitTagName)
+	if err != nil {
+		if errors.Is(err, errGithubReleaseNotFound) {
+			return svcerrors.NewGithubReleaseNotFoundError().Wrap(err)
+		}
+
+		return fmt.Errorf("failed to get release ID: %w", err)
+	}
+
+	_, err = c.getGithubClient(tkn).Repositories.DeleteRelease(
+		ctx,
+		repo.OwnerSlug,
+		repo.RepoSlug,
+		id,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to delete release: %w", err)
+	}
+
+	return nil
+}
+
+// createRelease is an internal method for creating a release.
+// returns internal errGithubReleaseAlreadyExists if the release already exists
+func (c *Client) createRelease(ctx context.Context, tkn string, repo svcmodel.GithubRepo, rls svcmodel.Release) error {
+	// Creates a new release
+	// Docs: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release
+	//
+	// TagName is the name of the tag to link the release to
+	// Name is the name of the release
+	// Body is the description of the release
+	_, _, err := c.getGithubClient(tkn).Repositories.CreateRelease(ctx, repo.OwnerSlug, repo.RepoSlug, &github.RepositoryRelease{
+		TagName: &rls.GitTagName,
+		Name:    &rls.ReleaseTitle,
+		Body:    &rls.ReleaseNotes,
+	})
+	var githubErr *github.ErrorResponse
+	if errors.As(err, &githubErr) && githubErr.Errors != nil {
+		// GitHub returns error response as an array of errors
+		// Each error contains fields (code, resource, field)
+		for _, e := range githubErr.Errors {
+			if e.Code == errCodeAlreadyExists && e.Field == gitTagNameField {
+				return errGithubReleaseAlreadyExists
+			}
+		}
+	}
+
+	return err
+}
+
+func (c *Client) updateRelease(ctx context.Context, tkn string, repo svcmodel.GithubRepo, rls svcmodel.Release) error {
+	// Release can be updated only by release ID
+	// Therefore I need to get release ID first
+	id, err := c.getReleaseIDByTag(ctx, tkn, repo, rls.GitTagName)
+	if err != nil {
+		return fmt.Errorf("failed to get release ID: %w", err)
+	}
+
+	// Updates a release
+	// Docs: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#update-a-release
+	//
+	// Name is the name of the release
+	// Body is the description of the release
+	_, _, err = c.getGithubClient(tkn).Repositories.EditRelease(
+		ctx,
+		repo.OwnerSlug,
+		repo.RepoSlug,
+		id,
+		&github.RepositoryRelease{
+			Name: &rls.ReleaseTitle,
+			Body: &rls.ReleaseNotes,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update release: %w", err)
+	}
+
+	return nil
+}
+
+// getReleaseByTag is an internal method for fetching a release ID.
+// This method simplifies the logic in other functions that need to get a release,
+// as it also returns the private error errGithubReleaseNotFound if the release is not found.
+// Other functions can then check if the error is equal to errGithubReleaseNotFound
+// and handle the error based on their use case.
+func (c *Client) getReleaseIDByTag(ctx context.Context, tkn string, repo svcmodel.GithubRepo, tagName string) (int64, error) {
+	rls, _, err := c.getGithubClient(tkn).Repositories.GetReleaseByTag(
+		ctx,
+		repo.OwnerSlug,
+		repo.RepoSlug,
+		tagName,
+	)
+	if err != nil {
+		var githubErr *github.ErrorResponse
+		if errors.As(err, &githubErr) && githubErr.Response.StatusCode == http.StatusNotFound {
+			return 0, errGithubReleaseNotFound
+		}
+
+		return 0, err
+	}
+
+	return rls.GetID(), nil
 }
 
 func (c *Client) getGithubClient(tkn string) *github.Client {

--- a/github/mock/client.go
+++ b/github/mock/client.go
@@ -13,12 +13,12 @@ type Client struct {
 	mock.Mock
 }
 
-func (c *Client) ReadTagsForRepository(ctx context.Context, tkn string, repoURL url.URL) ([]svcmodel.GitTag, error) {
+func (c *Client) ReadTagsForRepo(ctx context.Context, tkn string, repoURL url.URL) ([]svcmodel.GitTag, error) {
 	args := c.Called(ctx, tkn, repoURL)
 	return args.Get(0).([]svcmodel.GitTag), args.Error(1)
 }
 
-func (c *Client) ReadRepository(ctx context.Context, tkn string, rawRepoURL string) (svcmodel.GithubRepo, error) {
+func (c *Client) ReadRepo(ctx context.Context, tkn string, rawRepoURL string) (svcmodel.GithubRepo, error) {
 	args := c.Called(ctx, tkn, rawRepoURL)
 	return args.Get(0).(svcmodel.GithubRepo), args.Error(1)
 }

--- a/repository/model/project.go
+++ b/repository/model/project.go
@@ -43,7 +43,7 @@ func ToSvcProject(p Project) (svcmodel.Project, error) {
 	if p.GithubOwnerSlug.Valid && p.GithubRepoSlug.Valid && p.GithubRepoURL.Valid {
 		u, err := url.Parse(p.GithubRepoURL.String)
 		if err != nil {
-			return svcmodel.Project{}, fmt.Errorf("failed to parse github repository URL: %w", err)
+			return svcmodel.Project{}, fmt.Errorf("failed to parse github repo URL: %w", err)
 		}
 
 		githubRepo = &svcmodel.GithubRepo{
@@ -58,7 +58,7 @@ func ToSvcProject(p Project) (svcmodel.Project, error) {
 		Name:                      p.Name,
 		SlackChannelID:            p.SlackChannelID,
 		ReleaseNotificationConfig: svcmodel.ReleaseNotificationConfig(p.ReleaseNotificationConfig),
-		GithubRepositoryURL:       *u, // TODO remove
+		GithubRepoURL:             *u, // TODO remove
 		GithubRepo:                githubRepo,
 		CreatedAt:                 p.CreatedAt,
 		UpdatedAt:                 p.UpdatedAt,

--- a/repository/project.go
+++ b/repository/project.go
@@ -50,7 +50,7 @@ func (r *ProjectRepository) CreateProjectWithOwner(ctx context.Context, p svcmod
 		"releaseNotificationConfig": model.ReleaseNotificationConfig(p.ReleaseNotificationConfig), // converted to the struct with json tags (the field is saved as json in the database)
 		"createdAt":                 p.CreatedAt,
 		"updatedAt":                 p.UpdatedAt,
-		"githubRepositoryURL":       p.GithubRepositoryURL.String(), // TODO remove
+		"githubRepositoryURL":       p.GithubRepoURL.String(), // TODO remove
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create project: %w", err)
@@ -540,7 +540,7 @@ func toUpdateProjectArgs(p svcmodel.Project) pgx.NamedArgs {
 		"slackChannelID": p.SlackChannelID,
 		// Converted to the struct with json tags (the field is saved as json in the database).
 		"releaseNotificationConfig": model.ReleaseNotificationConfig(p.ReleaseNotificationConfig),
-		"githubRepositoryURL":       p.GithubRepositoryURL.String(), // TODO remove
+		"githubRepositoryURL":       p.GithubRepoURL.String(), // TODO remove
 		"githubOwnerSlug":           ownerSlug,
 		"githubRepoSlug":            repoSlug,
 		"githubRepoURL":             repoURL.String(),

--- a/service/errors/errors.go
+++ b/service/errors/errors.go
@@ -7,37 +7,37 @@ import (
 )
 
 var (
-	ErrCodeUnauthorizedUnknownUser                 = "ERR_UNAUTHORIZED_ACCESS_UNKNOWN_USER"
-	ErrCodeForbiddenInsufficientUserRole           = "ERR_FORBIDDEN_ACCESS_INSUFFICIENT_USER_ROLE"
-	ErrCodeForbiddenInsufficientProjectRole        = "ERR_FORBIDDEN_ACCESS_INSUFFICIENT_PROJECT_ROLE"
-	ErrCodeForbiddenUserNotProjectMember           = "ERR_FORBIDDEN_USER_NOT_PROJECT_MEMBER"
-	ErrCodeUserNotFound                            = "ERR_USER_NOT_FOUND"
-	ErrCodeProjectNotFound                         = "ERR_PROJECT_NOT_FOUND"
-	ErrCodeEnvironmentNotFound                     = "ERR_ENVIRONMENT_NOT_FOUND"
-	ErrCodeProjectUnprocessable                    = "ERR_PROJECT_UNPROCESSABLE"
-	ErrCodeEnvironmentUnprocessable                = "ERR_ENVIRONMENT_UNPROCESSABLE"
-	ErrCodeEnvironmentDuplicateName                = "ERR_ENVIRONMENT_DUPLICATE_NAME"
-	ErrCodeSettingsUnprocessable                   = "ERR_SETTINGS_UNPROCESSABLE"
-	ErrCodeProjectInvitationUnprocessable          = "ERR_PROJECT_INVITATION_UNPROCESSABLE"
-	ErrCodeProjectInvitationAlreadyExists          = "ERR_PROJECT_INVITATION_ALREADY_EXISTS"
-	ErrCodeProjectInvitationNotFound               = "ERR_PROJECT_INVITATION_NOT_FOUND"
-	ErrCodeProjectMemberAlreadyExists              = "ERR_PROJECT_MEMBER_ALREADY_EXISTS"
-	ErrCodeGithubIntegrationNotEnabled             = "ERR_GITHUB_INTEGRATION_NOT_ENABLED"
-	ErrCodeGithubClientUnauthorized                = "ERR_GITHUB_CLIENT_UNAUTHORIZED"
-	ErrCodeGithubClientForbidden                   = "ERR_GITHUB_CLIENT_FORBIDDEN"
-	ErrCodeGithubRepositoryNotConfiguredForProject = "ERR_GITHUB_REPOSITORY_NOT_CONFIGURED_FOR_PROJECT"
-	ErrCodeGithubRepositoryNotFound                = "ERR_GITHUB_REPOSITORY_NOT_FOUND"
-	ErrCodeGithubRepositoryInvalidURL              = "ERR_GITHUB_REPOSITORY_INVALID_URL"
-	ErrCodeProjectMemberNotFound                   = "ERR_PROJECT_MEMBER_NOT_FOUND"
-	ErrCodeProjectMemberUnprocessable              = "ERR_PROJECT_MEMBER_UNPROCESSABLE"
-	ErrCodeReleaseUnprocessable                    = "ERR_RELEASE_UNPROCESSABLE"
-	ErrCodeReleaseNotFound                         = "ERR_RELEASE_NOT_FOUND"
-	ErrCodeSlackIntegrationNotEnabled              = "ERR_SLACK_INTEGRATION_NOT_ENABLED"
-	ErrCodeSlackClientUnauthorized                 = "ERR_SLACK_CLIENT_UNAUTHORIZED"
-	ErrCodeSlackChannelNotFound                    = "ERR_SLACK_CHANNEL_NOT_FOUND"
-	ErrCodeSlackChannelNotSetForProject            = "ERR_SLACK_CHANNEL_NOT_SET_FOR_PROJECT"
-	ErrCodeGitTagNotFound                          = "ERR_GIT_TAG_NOT_FOUND"
-	ErrCodeGithubReleaseNotFound                   = "ERR_GITHUB_RELEASE_NOT_FOUND"
+	ErrCodeUnauthorizedUnknownUser           = "ERR_UNAUTHORIZED_ACCESS_UNKNOWN_USER"
+	ErrCodeForbiddenInsufficientUserRole     = "ERR_FORBIDDEN_ACCESS_INSUFFICIENT_USER_ROLE"
+	ErrCodeForbiddenInsufficientProjectRole  = "ERR_FORBIDDEN_ACCESS_INSUFFICIENT_PROJECT_ROLE"
+	ErrCodeForbiddenUserNotProjectMember     = "ERR_FORBIDDEN_USER_NOT_PROJECT_MEMBER"
+	ErrCodeUserNotFound                      = "ERR_USER_NOT_FOUND"
+	ErrCodeProjectNotFound                   = "ERR_PROJECT_NOT_FOUND"
+	ErrCodeEnvironmentNotFound               = "ERR_ENVIRONMENT_NOT_FOUND"
+	ErrCodeProjectUnprocessable              = "ERR_PROJECT_UNPROCESSABLE"
+	ErrCodeEnvironmentUnprocessable          = "ERR_ENVIRONMENT_UNPROCESSABLE"
+	ErrCodeEnvironmentDuplicateName          = "ERR_ENVIRONMENT_DUPLICATE_NAME"
+	ErrCodeSettingsUnprocessable             = "ERR_SETTINGS_UNPROCESSABLE"
+	ErrCodeProjectInvitationUnprocessable    = "ERR_PROJECT_INVITATION_UNPROCESSABLE"
+	ErrCodeProjectInvitationAlreadyExists    = "ERR_PROJECT_INVITATION_ALREADY_EXISTS"
+	ErrCodeProjectInvitationNotFound         = "ERR_PROJECT_INVITATION_NOT_FOUND"
+	ErrCodeProjectMemberAlreadyExists        = "ERR_PROJECT_MEMBER_ALREADY_EXISTS"
+	ErrCodeGithubIntegrationNotEnabled       = "ERR_GITHUB_INTEGRATION_NOT_ENABLED"
+	ErrCodeGithubClientUnauthorized          = "ERR_GITHUB_CLIENT_UNAUTHORIZED"
+	ErrCodeGithubClientForbidden             = "ERR_GITHUB_CLIENT_FORBIDDEN"
+	ErrCodeGithubRepoNotConfiguredForProject = "ERR_GITHUB_REPO_NOT_CONFIGURED_FOR_PROJECT"
+	ErrCodeGithubRepoNotFound                = "ERR_GITHUB_REPO_NOT_FOUND"
+	ErrCodeGithubRepoInvalidURL              = "ERR_GITHUB_REPO_INVALID_URL"
+	ErrCodeProjectMemberNotFound             = "ERR_PROJECT_MEMBER_NOT_FOUND"
+	ErrCodeProjectMemberUnprocessable        = "ERR_PROJECT_MEMBER_UNPROCESSABLE"
+	ErrCodeReleaseUnprocessable              = "ERR_RELEASE_UNPROCESSABLE"
+	ErrCodeReleaseNotFound                   = "ERR_RELEASE_NOT_FOUND"
+	ErrCodeSlackIntegrationNotEnabled        = "ERR_SLACK_INTEGRATION_NOT_ENABLED"
+	ErrCodeSlackClientUnauthorized           = "ERR_SLACK_CLIENT_UNAUTHORIZED"
+	ErrCodeSlackChannelNotFound              = "ERR_SLACK_CHANNEL_NOT_FOUND"
+	ErrCodeSlackChannelNotSetForProject      = "ERR_SLACK_CHANNEL_NOT_SET_FOR_PROJECT"
+	ErrCodeGitTagNotFound                    = "ERR_GIT_TAG_NOT_FOUND"
+	ErrCodeGithubReleaseNotFound             = "ERR_GITHUB_RELEASE_NOT_FOUND"
 )
 
 type Error struct {
@@ -168,10 +168,10 @@ func NewProjectMemberAlreadyExistsError() *Error {
 	}
 }
 
-func NewGithubRepositoryInvalidURL() *Error {
+func NewGithubRepoInvalidURL() *Error {
 	return &Error{
-		Code:    ErrCodeGithubRepositoryInvalidURL,
-		Message: "Invalid Github repository URL.",
+		Code:    ErrCodeGithubRepoInvalidURL,
+		Message: "Invalid Github repo URL.",
 	}
 }
 
@@ -182,10 +182,10 @@ func NewGithubIntegrationNotEnabledError() *Error {
 	}
 }
 
-func NewGithubRepositoryNotConfiguredForProjectError() *Error {
+func NewGithubRepoNotConfiguredForProjectError() *Error {
 	return &Error{
-		Code:    ErrCodeGithubRepositoryNotConfiguredForProject,
-		Message: "Github repository is not configured for the project.",
+		Code:    ErrCodeGithubRepoNotConfiguredForProject,
+		Message: "Github repo is not configured for the project.",
 	}
 }
 
@@ -203,10 +203,10 @@ func NewGithubClientForbiddenError() *Error {
 	}
 }
 
-func NewGithubRepositoryNotFoundError() *Error {
+func NewGithubRepoNotFoundError() *Error {
 	return &Error{
-		Code:    ErrCodeGithubRepositoryNotFound,
-		Message: "Github repository not found among accessible repositories.",
+		Code:    ErrCodeGithubRepoNotFound,
+		Message: "Github repo not found among accessible repos.",
 	}
 }
 
@@ -285,12 +285,12 @@ func IsNotFoundError(err error) bool {
 		isErrorWithCode(err, ErrCodeProjectNotFound) ||
 		isErrorWithCode(err, ErrCodeEnvironmentNotFound) ||
 		isErrorWithCode(err, ErrCodeProjectInvitationNotFound) ||
-		isErrorWithCode(err, ErrCodeGithubRepositoryNotFound) ||
-		isErrorWithCode(err, ErrCodeGithubRepositoryNotConfiguredForProject) ||
+		isErrorWithCode(err, ErrCodeGithubRepoNotFound) ||
+		isErrorWithCode(err, ErrCodeGithubRepoNotConfiguredForProject) ||
 		isErrorWithCode(err, ErrCodeGithubIntegrationNotEnabled) ||
 		isErrorWithCode(err, ErrCodeProjectMemberNotFound) ||
 		isErrorWithCode(err, ErrCodeGithubIntegrationNotEnabled) ||
-		isErrorWithCode(err, ErrCodeGithubRepositoryInvalidURL) ||
+		isErrorWithCode(err, ErrCodeGithubRepoInvalidURL) ||
 		isErrorWithCode(err, ErrCodeReleaseNotFound) ||
 		isErrorWithCode(err, ErrCodeGitTagNotFound) ||
 		isErrorWithCode(err, ErrCodeGithubReleaseNotFound)

--- a/service/model/project.go
+++ b/service/model/project.go
@@ -21,7 +21,7 @@ type Project struct {
 	Name                      string
 	SlackChannelID            string
 	ReleaseNotificationConfig ReleaseNotificationConfig
-	GithubRepositoryURL       url.URL // TODO remove this field
+	GithubRepoURL             url.URL // TODO remove this field
 	GithubRepo                *GithubRepo
 	CreatedAt                 time.Time
 	UpdatedAt                 time.Time
@@ -37,14 +37,14 @@ type CreateProjectInput struct {
 	Name                      string
 	SlackChannelID            string
 	ReleaseNotificationConfig ReleaseNotificationConfig
-	GithubRepositoryRawURL    string // TODO remove this field
+	GithubRepoRawURL          string // TODO remove this field
 }
 
 type UpdateProjectInput struct {
 	Name                            *string
 	SlackChannelID                  *string
 	ReleaseNotificationConfigUpdate UpdateReleaseNotificationConfigInput
-	GithubRepositoryRawURL          *string // TODO remove this field
+	GithubRepoRawURL                *string // TODO remove this field
 }
 
 type ReleaseNotificationConfig struct {
@@ -66,7 +66,7 @@ type UpdateReleaseNotificationConfigInput struct {
 }
 
 func NewProject(c CreateProjectInput) (Project, error) {
-	u, err := url.Parse(c.GithubRepositoryRawURL)
+	u, err := url.Parse(c.GithubRepoRawURL)
 	if err != nil {
 		return Project{}, errProjectGithubRepoURLCannotBeParsed
 	}
@@ -77,7 +77,7 @@ func NewProject(c CreateProjectInput) (Project, error) {
 		Name:                      c.Name,
 		SlackChannelID:            c.SlackChannelID,
 		ReleaseNotificationConfig: c.ReleaseNotificationConfig,
-		GithubRepositoryURL:       *u,
+		GithubRepoURL:             *u,
 		CreatedAt:                 now,
 		UpdatedAt:                 now,
 	}
@@ -97,13 +97,13 @@ func (p *Project) SetGithubRepo(repo *GithubRepo) {
 type UpdateProjectFunc func(p Project) (Project, error)
 
 func (p *Project) Update(u UpdateProjectInput) error {
-	if u.GithubRepositoryRawURL != nil {
-		u, err := url.Parse(*u.GithubRepositoryRawURL)
+	if u.GithubRepoRawURL != nil {
+		u, err := url.Parse(*u.GithubRepoRawURL)
 		if err != nil {
 			return errProjectGithubRepoURLCannotBeParsed
 		}
 
-		p.GithubRepositoryURL = *u
+		p.GithubRepoURL = *u
 	}
 	if u.Name != nil {
 		p.Name = *u.Name
@@ -131,7 +131,7 @@ func (p *Project) IsSlackChannelSet() bool {
 }
 
 func (p *Project) IsGithubConfigured() bool {
-	return p.GithubRepositoryURL != (url.URL{})
+	return p.GithubRepoURL != (url.URL{})
 }
 
 func (c *ReleaseNotificationConfig) Update(u UpdateReleaseNotificationConfigInput) {

--- a/service/project.go
+++ b/service/project.go
@@ -165,9 +165,9 @@ func (s *ProjectService) SetGithubRepoForProject(ctx context.Context, rawRepoURL
 		return fmt.Errorf("getting Github token: %w", err)
 	}
 
-	repo, err := s.githubManager.ReadRepository(ctx, tkn, rawRepoURL)
+	repo, err := s.githubManager.ReadRepo(ctx, tkn, rawRepoURL)
 	if err != nil {
-		return fmt.Errorf("reading github repository: %w", err)
+		return fmt.Errorf("reading github repo: %w", err)
 	}
 
 	_, err = s.repo.UpdateProject(ctx, projectID, func(p model.Project) (model.Project, error) {
@@ -175,7 +175,7 @@ func (s *ProjectService) SetGithubRepoForProject(ctx context.Context, rawRepoURL
 		return p, nil
 	})
 	if err != nil {
-		return fmt.Errorf("updating project with Github repository: %w", err)
+		return fmt.Errorf("updating project with Github repo: %w", err)
 	}
 
 	return nil
@@ -277,7 +277,7 @@ func (s *ProjectService) DeleteEnvironment(ctx context.Context, projectID, envID
 	return nil
 }
 
-func (s *ProjectService) ListGithubRepositoryTags(ctx context.Context, projectID, authUserID uuid.UUID) ([]model.GitTag, error) {
+func (s *ProjectService) ListGithubRepoTags(ctx context.Context, projectID, authUserID uuid.UUID) ([]model.GitTag, error) {
 	if err := s.authGuard.AuthorizeProjectRoleViewer(ctx, projectID, authUserID); err != nil {
 		return nil, fmt.Errorf("authorizing project member: %w", err)
 	}
@@ -293,12 +293,12 @@ func (s *ProjectService) ListGithubRepositoryTags(ctx context.Context, projectID
 	}
 
 	if !project.IsGithubConfigured() {
-		return nil, svcerrors.NewGithubRepositoryNotConfiguredForProjectError()
+		return nil, svcerrors.NewGithubRepoNotConfiguredForProjectError()
 	}
 
-	t, err := s.githubManager.ReadTagsForRepository(ctx, tkn, project.GithubRepositoryURL)
+	t, err := s.githubManager.ReadTagsForRepo(ctx, tkn, project.GithubRepoURL)
 	if err != nil {
-		return nil, fmt.Errorf("reading tags for github repository: %w", err)
+		return nil, fmt.Errorf("reading tags for github repo: %w", err)
 	}
 
 	return t, nil

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -84,7 +84,7 @@ func TestProjectService_CreateProject(t *testing.T) {
 				Name:                      "",
 				SlackChannelID:            "",
 				ReleaseNotificationConfig: model.ReleaseNotificationConfig{Message: "test message"},
-				GithubRepositoryRawURL:    "https://github.com/owner",
+				GithubRepoRawURL:          "https://github.com/owner",
 			},
 			mockSetup: func(auth *svc.AuthorizeService, settings *svc.SettingsService, user *svc.UserService, github *githubmock.Client, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)

--- a/service/service.go
+++ b/service/service.go
@@ -83,8 +83,8 @@ type projectGetter interface {
 }
 
 type githubManager interface {
-	ReadRepository(ctx context.Context, token, rawRepoURL string) (model.GithubRepo, error)
-	ReadTagsForRepository(ctx context.Context, token string, repoURL url.URL) ([]model.GitTag, error)
+	ReadRepo(ctx context.Context, token, rawRepoURL string) (model.GithubRepo, error)
+	ReadTagsForRepo(ctx context.Context, token string, repoURL url.URL) ([]model.GitTag, error)
 }
 
 type emailSender interface {

--- a/transport/errors/errormapper.go
+++ b/transport/errors/errormapper.go
@@ -30,12 +30,12 @@ func isNotFoundError(err error) bool {
 		isSvcErrorWithCode(err, svcerrors.ErrCodeProjectNotFound) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeEnvironmentNotFound) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeProjectInvitationNotFound) ||
-		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubRepositoryNotFound) ||
-		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubRepositoryNotConfiguredForProject) ||
+		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubRepoNotFound) ||
+		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubRepoNotConfiguredForProject) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubIntegrationNotEnabled) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeProjectMemberNotFound) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubIntegrationNotEnabled) ||
-		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubRepositoryInvalidURL) ||
+		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubRepoInvalidURL) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeReleaseNotFound) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeGitTagNotFound) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubReleaseNotFound) ||

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -24,7 +24,7 @@ type projectService interface {
 	DeleteEnvironment(ctx context.Context, projectID, envID, authUserID uuid.UUID) error
 	UpdateEnvironment(ctx context.Context, u svcmodel.UpdateEnvironmentInput, projectID, envID, authUserID uuid.UUID) (svcmodel.Environment, error)
 
-	ListGithubRepositoryTags(ctx context.Context, projectID, authUserID uuid.UUID) ([]svcmodel.GitTag, error)
+	ListGithubRepoTags(ctx context.Context, projectID, authUserID uuid.UUID) ([]svcmodel.GitTag, error)
 
 	Invite(ctx context.Context, c svcmodel.CreateProjectInvitationInput, authUserID uuid.UUID) (svcmodel.ProjectInvitation, error)
 	ListInvitations(ctx context.Context, projectID, authUserID uuid.UUID) ([]svcmodel.ProjectInvitation, error)

--- a/transport/handler/project.go
+++ b/transport/handler/project.go
@@ -79,8 +79,8 @@ func (h *Handler) deleteProject(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *Handler) listGithubRepositoryTags(w http.ResponseWriter, r *http.Request) {
-	t, err := h.ProjectSvc.ListGithubRepositoryTags(
+func (h *Handler) listGithubRepoTags(w http.ResponseWriter, r *http.Request) {
+	t, err := h.ProjectSvc.ListGithubRepoTags(
 		r.Context(),
 		util.ContextProjectID(r),
 		util.ContextAuthUserID(r),

--- a/transport/handler/routes.go
+++ b/transport/handler/routes.go
@@ -59,9 +59,9 @@ func (h *Handler) setupRoutes() {
 					r.Patch("/", middleware.RequireAuthUser(h.updateMemberRole))
 				})
 			})
-			r.Route("/github-repository", func(r chi.Router) {
+			r.Route("/github-repo", func(r chi.Router) {
 				r.Post("/", middleware.RequireAuthUser(h.setGithubRepoForProject))
-				r.Get("/tags", middleware.RequireAuthUser(h.listGithubRepositoryTags))
+				r.Get("/tags", middleware.RequireAuthUser(h.listGithubRepoTags))
 			})
 			r.Route("/releases", func(r chi.Router) {
 				r.Get("/", middleware.RequireAuthUser(h.listReleases))

--- a/transport/model/project.go
+++ b/transport/model/project.go
@@ -12,14 +12,14 @@ type CreateProjectInput struct {
 	Name                      string                    `json:"name"`
 	SlackChannelID            string                    `json:"slack_channel_id"`
 	ReleaseNotificationConfig ReleaseNotificationConfig `json:"release_notification_config"`
-	GithubRepositoryURL       string                    `json:"github_repository_url"` // TODO remove
+	GithubRepoURL             string                    `json:"github_repository_url"` // TODO remove
 }
 
 type UpdateProjectInput struct {
 	Name                      *string                              `json:"name"`
 	SlackChannelID            *string                              `json:"slack_channel_id"`
 	ReleaseNotificationConfig UpdateReleaseNotificationConfigInput `json:"release_notification_config"`
-	GithubRepositoryURL       *string                              `json:"github_repository_url"` // TODO remove
+	GithubRepoURL             *string                              `json:"github_repository_url"` // TODO remove
 }
 
 type SetProjectGithubRepoInput struct {
@@ -31,7 +31,7 @@ type Project struct {
 	Name                      string                    `json:"name"`
 	SlackChannelID            string                    `json:"slack_channel_id"`
 	ReleaseNotificationConfig ReleaseNotificationConfig `json:"release_notification_config"`
-	GithubRepository          string                    `json:"github_repository_url"` // TODO remove this field
+	GithubRepo                string                    `json:"github_repository_url"` // TODO remove this field
 	CreatedAt                 time.Time                 `json:"created_at"`
 	UpdatedAt                 time.Time                 `json:"updated_at"`
 }
@@ -59,7 +59,7 @@ func ToSvcCreateProjectInput(c CreateProjectInput) svcmodel.CreateProjectInput {
 		Name:                      c.Name,
 		SlackChannelID:            c.SlackChannelID,
 		ReleaseNotificationConfig: svcmodel.ReleaseNotificationConfig(c.ReleaseNotificationConfig),
-		GithubRepositoryRawURL:    c.GithubRepositoryURL,
+		GithubRepoRawURL:          c.GithubRepoURL,
 	}
 }
 
@@ -68,7 +68,7 @@ func ToSvcUpdateProjectInput(u UpdateProjectInput) svcmodel.UpdateProjectInput {
 		Name:                            u.Name,
 		SlackChannelID:                  u.SlackChannelID,
 		ReleaseNotificationConfigUpdate: svcmodel.UpdateReleaseNotificationConfigInput(u.ReleaseNotificationConfig),
-		GithubRepositoryRawURL:          u.GithubRepositoryURL,
+		GithubRepoRawURL:                u.GithubRepoURL,
 	}
 }
 
@@ -78,7 +78,7 @@ func ToProject(p svcmodel.Project) Project {
 		Name:                      p.Name,
 		SlackChannelID:            p.SlackChannelID,
 		ReleaseNotificationConfig: ReleaseNotificationConfig(p.ReleaseNotificationConfig),
-		GithubRepository:          p.GithubRepositoryURL.String(),
+		GithubRepo:                p.GithubRepoURL.String(),
 		CreatedAt:                 p.CreatedAt,
 		UpdatedAt:                 p.UpdatedAt,
 	}

--- a/transport/model/webhook.go
+++ b/transport/model/webhook.go
@@ -6,7 +6,7 @@ type GithubRefWebhookInput struct {
 	// RefType is the type of the reference (e.g. "branch" or "tag")
 	RefType string `json:"ref_type" required:"true"`
 	Repo    struct {
-		// Owner and repository slug of the GitHub repository separated by a slash
+		// Owner and repo slug of the GitHub repo separated by a slash
 		// (e.g. "owner/repo")
 		Slugs string `json:"full_name"`
 	} `json:"repository"`


### PR DESCRIPTION
As we agreeded, user will have have options:
- `populate [release changes] to github` -> github release is either created or updated (->upsert method added)
- when deleting a release, you can request to delete github release as well (-> delete method added)