### PR TITLE
feat(github-client): add function to dynamically generate git tag URL

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -230,6 +230,16 @@ func (c *Client) updateRelease(ctx context.Context, tkn string, repo svcmodel.Gi
 	return nil
 }
 
+func (c *Client) GenerateGitTagURL(repo svcmodel.GithubRepo, tagName string) (url.URL, error) {
+	rawURL := fmt.Sprintf("https://github.com/%s/%s/releases/tag/%s", repo.OwnerSlug, repo.RepoSlug, tagName)
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return url.URL{}, err
+	}
+
+	return *u, nil
+}
+
 // getReleaseByTag is an internal method for fetching a release ID.
 // This method simplifies the logic in other functions that need to get a release,
 // as it also returns the private error errGithubReleaseNotFound if the release is not found.

--- a/github/mock/client.go
+++ b/github/mock/client.go
@@ -22,3 +22,8 @@ func (c *Client) ReadRepo(ctx context.Context, tkn string, rawRepoURL string) (s
 	args := c.Called(ctx, tkn, rawRepoURL)
 	return args.Get(0).(svcmodel.GithubRepo), args.Error(1)
 }
+
+func (c *Client) GenerateGitTagURL(repo svcmodel.GithubRepo, tagName string) (url.URL, error) {
+	args := c.Called(repo, tagName)
+	return args.Get(0).(url.URL), args.Error(1)
+}


### PR DESCRIPTION
Git tag URL will be generated dynamically.