### PR TITLE
feat(release svc): add git tag to release creation

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -100,7 +100,7 @@ func (c *Client) ReadTagsForRepo(ctx context.Context, tkn string, repo svcmodel.
 	return model.ToSvcGitTags(t), nil
 }
 
-func (c *Client) ReadTagByName(ctx context.Context, tkn string, repo svcmodel.GithubRepo, tagName string) (svcmodel.GitTag, error) {
+func (c *Client) TagExists(ctx context.Context, tkn string, repo svcmodel.GithubRepo, tagName string) (bool, error) {
 	// Git tag can be fetched only by its SHA, using GET /repos/{owner}/{repo}/git/tags/{tag_sha}
 	// Another limitation is that only annotated tags can be fetched by /repos/{owner}/{repo}/git/tags/{tag_sha}
 	// Because lightweight tags do not have their own SHA, they only reference a commit
@@ -117,13 +117,13 @@ func (c *Client) ReadTagByName(ctx context.Context, tkn string, repo svcmodel.Gi
 	if err != nil {
 		var githubErr *github.ErrorResponse
 		if errors.As(err, &githubErr) && githubErr.Response.StatusCode == http.StatusNotFound {
-			return svcmodel.GitTag{}, svcerrors.NewGitTagNotFoundError().Wrap(err)
+			return false, nil
 		}
 
-		return svcmodel.GitTag{}, err
+		return false, err
 	}
 
-	return svcmodel.GitTag{Name: tagName}, nil
+	return true, nil
 }
 
 func (c *Client) UpsertRelease(ctx context.Context, tkn string, repo svcmodel.GithubRepo, rls svcmodel.Release) error {

--- a/github/mock/client.go
+++ b/github/mock/client.go
@@ -32,3 +32,8 @@ func (c *Client) DeleteReleaseByTag(ctx context.Context, tkn string, repo svcmod
 	args := c.Called(ctx, tkn, repo, tagName)
 	return args.Error(0)
 }
+
+func (c *Client) TagExists(ctx context.Context, tkn string, repo svcmodel.GithubRepo, tagName string) (bool, error) {
+	args := c.Called(ctx, tkn, repo, tagName)
+	return args.Bool(0), args.Error(1)
+}

--- a/repository/model/release.go
+++ b/repository/model/release.go
@@ -14,6 +14,7 @@ type Release struct {
 	ReleaseTitle string    `db:"release_title"`
 	ReleaseNotes string    `db:"release_notes"`
 	AuthorUserID uuid.UUID `db:"created_by"`
+	GitTagName   string    `db:"git_tag_name"`
 	CreatedAt    time.Time `db:"created_at"`
 	UpdatedAt    time.Time `db:"updated_at"`
 }

--- a/repository/query/scripts/create_release.sql
+++ b/repository/query/scripts/create_release.sql
@@ -1,2 +1,2 @@
-INSERT INTO releases (id, project_id, release_title, release_notes, created_by, created_at, updated_at)
-VALUES (@id, @projectID, @releaseTitle, @releaseNotes, @createdBy, @createdAt, @updatedAt)
+INSERT INTO releases (id, project_id, release_title, release_notes, git_tag_name, created_by, created_at, updated_at)
+VALUES (@id, @projectID, @releaseTitle, @releaseNotes, @gitTagName, @createdBy, @createdAt, @updatedAt)

--- a/service/errors/errors.go
+++ b/service/errors/errors.go
@@ -7,37 +7,38 @@ import (
 )
 
 var (
-	ErrCodeUnauthorizedUnknownUser           = "ERR_UNAUTHORIZED_ACCESS_UNKNOWN_USER"
-	ErrCodeForbiddenInsufficientUserRole     = "ERR_FORBIDDEN_ACCESS_INSUFFICIENT_USER_ROLE"
-	ErrCodeForbiddenInsufficientProjectRole  = "ERR_FORBIDDEN_ACCESS_INSUFFICIENT_PROJECT_ROLE"
-	ErrCodeForbiddenUserNotProjectMember     = "ERR_FORBIDDEN_USER_NOT_PROJECT_MEMBER"
-	ErrCodeUserNotFound                      = "ERR_USER_NOT_FOUND"
-	ErrCodeProjectNotFound                   = "ERR_PROJECT_NOT_FOUND"
-	ErrCodeEnvironmentNotFound               = "ERR_ENVIRONMENT_NOT_FOUND"
-	ErrCodeProjectUnprocessable              = "ERR_PROJECT_UNPROCESSABLE"
-	ErrCodeEnvironmentUnprocessable          = "ERR_ENVIRONMENT_UNPROCESSABLE"
-	ErrCodeEnvironmentDuplicateName          = "ERR_ENVIRONMENT_DUPLICATE_NAME"
-	ErrCodeSettingsUnprocessable             = "ERR_SETTINGS_UNPROCESSABLE"
-	ErrCodeProjectInvitationUnprocessable    = "ERR_PROJECT_INVITATION_UNPROCESSABLE"
-	ErrCodeProjectInvitationAlreadyExists    = "ERR_PROJECT_INVITATION_ALREADY_EXISTS"
-	ErrCodeProjectInvitationNotFound         = "ERR_PROJECT_INVITATION_NOT_FOUND"
-	ErrCodeProjectMemberAlreadyExists        = "ERR_PROJECT_MEMBER_ALREADY_EXISTS"
-	ErrCodeGithubIntegrationNotEnabled       = "ERR_GITHUB_INTEGRATION_NOT_ENABLED"
-	ErrCodeGithubClientUnauthorized          = "ERR_GITHUB_CLIENT_UNAUTHORIZED"
-	ErrCodeGithubClientForbidden             = "ERR_GITHUB_CLIENT_FORBIDDEN"
-	ErrCodeGithubRepoNotConfiguredForProject = "ERR_GITHUB_REPO_NOT_CONFIGURED_FOR_PROJECT"
-	ErrCodeGithubRepoNotFound                = "ERR_GITHUB_REPO_NOT_FOUND"
-	ErrCodeGithubRepoInvalidURL              = "ERR_GITHUB_REPO_INVALID_URL"
-	ErrCodeProjectMemberNotFound             = "ERR_PROJECT_MEMBER_NOT_FOUND"
-	ErrCodeProjectMemberUnprocessable        = "ERR_PROJECT_MEMBER_UNPROCESSABLE"
-	ErrCodeReleaseUnprocessable              = "ERR_RELEASE_UNPROCESSABLE"
-	ErrCodeReleaseNotFound                   = "ERR_RELEASE_NOT_FOUND"
-	ErrCodeSlackIntegrationNotEnabled        = "ERR_SLACK_INTEGRATION_NOT_ENABLED"
-	ErrCodeSlackClientUnauthorized           = "ERR_SLACK_CLIENT_UNAUTHORIZED"
-	ErrCodeSlackChannelNotFound              = "ERR_SLACK_CHANNEL_NOT_FOUND"
-	ErrCodeSlackChannelNotSetForProject      = "ERR_SLACK_CHANNEL_NOT_SET_FOR_PROJECT"
-	ErrCodeGitTagNotFound                    = "ERR_GIT_TAG_NOT_FOUND"
-	ErrCodeGithubReleaseNotFound             = "ERR_GITHUB_RELEASE_NOT_FOUND"
+	ErrCodeUnauthorizedUnknownUser          = "ERR_UNAUTHORIZED_ACCESS_UNKNOWN_USER"
+	ErrCodeForbiddenInsufficientUserRole    = "ERR_FORBIDDEN_ACCESS_INSUFFICIENT_USER_ROLE"
+	ErrCodeForbiddenInsufficientProjectRole = "ERR_FORBIDDEN_ACCESS_INSUFFICIENT_PROJECT_ROLE"
+	ErrCodeForbiddenUserNotProjectMember    = "ERR_FORBIDDEN_USER_NOT_PROJECT_MEMBER"
+	ErrCodeUserNotFound                     = "ERR_USER_NOT_FOUND"
+	ErrCodeProjectNotFound                  = "ERR_PROJECT_NOT_FOUND"
+	ErrCodeEnvironmentNotFound              = "ERR_ENVIRONMENT_NOT_FOUND"
+	ErrCodeProjectUnprocessable             = "ERR_PROJECT_UNPROCESSABLE"
+	ErrCodeEnvironmentUnprocessable         = "ERR_ENVIRONMENT_UNPROCESSABLE"
+	ErrCodeEnvironmentDuplicateName         = "ERR_ENVIRONMENT_DUPLICATE_NAME"
+	ErrCodeSettingsUnprocessable            = "ERR_SETTINGS_UNPROCESSABLE"
+	ErrCodeProjectInvitationUnprocessable   = "ERR_PROJECT_INVITATION_UNPROCESSABLE"
+	ErrCodeProjectInvitationAlreadyExists   = "ERR_PROJECT_INVITATION_ALREADY_EXISTS"
+	ErrCodeProjectInvitationNotFound        = "ERR_PROJECT_INVITATION_NOT_FOUND"
+	ErrCodeProjectMemberAlreadyExists       = "ERR_PROJECT_MEMBER_ALREADY_EXISTS"
+	ErrCodeGithubIntegrationNotEnabled      = "ERR_GITHUB_INTEGRATION_NOT_ENABLED"
+	ErrCodeGithubClientUnauthorized         = "ERR_GITHUB_CLIENT_UNAUTHORIZED"
+	ErrCodeGithubClientForbidden            = "ERR_GITHUB_CLIENT_FORBIDDEN"
+	ErrCodeGithubRepoNotSetForProject       = "ERR_GITHUB_REPO_NOT_SET_FOR_PROJECT"
+	ErrCodeGithubRepoNotFound               = "ERR_GITHUB_REPO_NOT_FOUND"
+	ErrCodeGithubRepoInvalidURL             = "ERR_GITHUB_REPO_INVALID_URL"
+	ErrCodeProjectMemberNotFound            = "ERR_PROJECT_MEMBER_NOT_FOUND"
+	ErrCodeProjectMemberUnprocessable       = "ERR_PROJECT_MEMBER_UNPROCESSABLE"
+	ErrCodeReleaseUnprocessable             = "ERR_RELEASE_UNPROCESSABLE"
+	ErrCodeReleaseNotFound                  = "ERR_RELEASE_NOT_FOUND"
+	ErrCodeSlackIntegrationNotEnabled       = "ERR_SLACK_INTEGRATION_NOT_ENABLED"
+	ErrCodeSlackClientUnauthorized          = "ERR_SLACK_CLIENT_UNAUTHORIZED"
+	ErrCodeSlackChannelNotFound             = "ERR_SLACK_CHANNEL_NOT_FOUND"
+	ErrCodeSlackChannelNotSetForProject     = "ERR_SLACK_CHANNEL_NOT_SET_FOR_PROJECT"
+	ErrCodeGitTagNotFound                   = "ERR_GIT_TAG_NOT_FOUND"
+	ErrCodeGithubReleaseNotFound            = "ERR_GITHUB_RELEASE_NOT_FOUND"
+	ErrCodeReleaseGitTagAlreadyUsed         = "ERR_RELEASE_GIT_TAG_ALREADY_USED"
 )
 
 type Error struct {
@@ -182,10 +183,10 @@ func NewGithubIntegrationNotEnabledError() *Error {
 	}
 }
 
-func NewGithubRepoNotConfiguredForProjectError() *Error {
+func NewGithubRepoNotSetForProjectError() *Error {
 	return &Error{
-		Code:    ErrCodeGithubRepoNotConfiguredForProject,
-		Message: "Github repo is not configured for the project.",
+		Code:    ErrCodeGithubRepoNotSetForProject,
+		Message: "Github repo is not set for the project.",
 	}
 }
 
@@ -280,13 +281,20 @@ func NewGithubReleaseNotFoundError() *Error {
 	}
 }
 
+func NewReleaseGitTagAlreadyUsedError() *Error {
+	return &Error{
+		Code:    ErrCodeReleaseGitTagAlreadyUsed,
+		Message: "Git tag is already used for another release",
+	}
+}
+
 func IsNotFoundError(err error) bool {
 	return isErrorWithCode(err, ErrCodeUserNotFound) ||
 		isErrorWithCode(err, ErrCodeProjectNotFound) ||
 		isErrorWithCode(err, ErrCodeEnvironmentNotFound) ||
 		isErrorWithCode(err, ErrCodeProjectInvitationNotFound) ||
 		isErrorWithCode(err, ErrCodeGithubRepoNotFound) ||
-		isErrorWithCode(err, ErrCodeGithubRepoNotConfiguredForProject) ||
+		isErrorWithCode(err, ErrCodeGithubRepoNotSetForProject) ||
 		isErrorWithCode(err, ErrCodeGithubIntegrationNotEnabled) ||
 		isErrorWithCode(err, ErrCodeProjectMemberNotFound) ||
 		isErrorWithCode(err, ErrCodeGithubIntegrationNotEnabled) ||

--- a/service/model/release_test.go
+++ b/service/model/release_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"net/url"
 	"testing"
 	"time"
 
@@ -20,6 +21,11 @@ func TestRelease_NewRelease(t *testing.T) {
 				ReleaseTitle: "Release 1.0",
 				ReleaseNotes: "Initial release",
 				GitTagName:   "v1.0.0",
+				GitTagURL: url.URL{
+					Scheme: "https",
+					Host:   "github.com",
+					Path:   "/owner/repo/releases/tag/v1.0.0",
+				},
 			},
 			wantErr: false,
 		},
@@ -29,6 +35,11 @@ func TestRelease_NewRelease(t *testing.T) {
 				ReleaseTitle: "",
 				ReleaseNotes: "Initial release",
 				GitTagName:   "v1.0.0",
+				GitTagURL: url.URL{
+					Scheme: "https",
+					Host:   "github.com",
+					Path:   "/owner/repo/releases/tag/v1.0.0",
+				},
 			},
 			wantErr: true,
 		},
@@ -75,6 +86,12 @@ func TestRelease_Update(t *testing.T) {
 			want: Release{
 				ReleaseTitle: validTitle,
 				ReleaseNotes: validNotes,
+				GitTagName:   "v1.0.0",
+				GitTagURL: url.URL{
+					Scheme: "https",
+					Host:   "github.com",
+					Path:   "/owner/repo/releases/tag/v1.0.0",
+				},
 			},
 			wantErr: false,
 		},
@@ -94,6 +111,12 @@ func TestRelease_Update(t *testing.T) {
 				ProjectID:    uuid.New(),
 				ReleaseTitle: "Initial Title",
 				ReleaseNotes: "Initial Notes",
+				GitTagName:   "v1.0.0",
+				GitTagURL: url.URL{
+					Scheme: "https",
+					Host:   "github.com",
+					Path:   "/owner/repo/releases/tag/v1.0.0",
+				},
 				AuthorUserID: uuid.New(),
 				CreatedAt:    time.Now(),
 				UpdatedAt:    time.Now(),
@@ -108,6 +131,40 @@ func TestRelease_Update(t *testing.T) {
 				assert.Equal(t, tt.want.ReleaseTitle, r.ReleaseTitle)
 				assert.Equal(t, tt.want.ReleaseNotes, r.ReleaseNotes)
 				assert.True(t, r.UpdatedAt.After(tt.want.UpdatedAt))
+			}
+		})
+	}
+}
+
+func TestCreateReleaseInput_ValidateGitTagName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   CreateReleaseInput
+		wantErr bool
+	}{
+		{
+			name: "Valid Git Tag Name",
+			input: CreateReleaseInput{
+				GitTagName: "v1.0.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Empty Git Tag Name",
+			input: CreateReleaseInput{
+				GitTagName: "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.input.ValidateGitTagName()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/service/project.go
+++ b/service/project.go
@@ -293,7 +293,7 @@ func (s *ProjectService) ListGithubRepoTags(ctx context.Context, projectID, auth
 	}
 
 	if !project.IsGithubRepoSet() {
-		return nil, svcerrors.NewGithubRepoNotConfiguredForProjectError()
+		return nil, svcerrors.NewGithubRepoNotSetForProjectError()
 	}
 
 	t, err := s.githubManager.ReadTagsForRepo(ctx, tkn, *project.GithubRepo)

--- a/service/release.go
+++ b/service/release.go
@@ -15,6 +15,7 @@ type ReleaseService struct {
 	projectGetter  projectGetter
 	settingsGetter settingsGetter
 	slackNotifier  slackNotifier
+	githubManager  githubManager
 	repo           releaseRepository
 }
 
@@ -23,6 +24,7 @@ func NewReleaseService(
 	projectGetter projectGetter,
 	settingsGetter settingsGetter,
 	notifier slackNotifier,
+	manager githubManager,
 	repo releaseRepository,
 ) *ReleaseService {
 	return &ReleaseService{
@@ -30,6 +32,7 @@ func NewReleaseService(
 		projectGetter:  projectGetter,
 		settingsGetter: settingsGetter,
 		slackNotifier:  notifier,
+		githubManager:  manager,
 		repo:           repo,
 	}
 }
@@ -44,13 +47,38 @@ func (s *ReleaseService) Create(
 		return model.Release{}, fmt.Errorf("authorizing project member: %w", err)
 	}
 
-	exists, err := s.projectGetter.ProjectExists(ctx, projectID, authorUserID)
+	tkn, err := s.settingsGetter.GetGithubToken(ctx)
 	if err != nil {
-		return model.Release{}, fmt.Errorf("checking project existence: %w", err)
+		return model.Release{}, fmt.Errorf("getting github token: %w", err)
 	}
-	if !exists {
-		return model.Release{}, svcerrors.NewProjectNotFoundError()
+
+	p, err := s.projectGetter.GetProject(ctx, projectID, authorUserID)
+	if err != nil {
+		return model.Release{}, fmt.Errorf("getting project: %w", err)
 	}
+
+	if !p.IsGithubRepoSet() {
+		return model.Release{}, svcerrors.NewGithubRepoNotSetForProjectError()
+	}
+
+	// Before checking if the tag exists, validate if git tag name was provided in order to avoid unnecessary API calls.
+	if err := input.ValidateGitTagName(); err != nil {
+		return model.Release{}, svcerrors.NewReleaseUnprocessableError().Wrap(err).WithMessage(err.Error())
+	}
+
+	tagExists, err := s.githubManager.TagExists(ctx, tkn, *p.GithubRepo, input.GitTagName)
+	if err != nil {
+		return model.Release{}, fmt.Errorf("checking if tag exists: %w", err)
+	}
+	if !tagExists {
+		return model.Release{}, svcerrors.NewGitTagNotFoundError()
+	}
+
+	gitTagURL, err := s.githubManager.GenerateGitTagURL(*p.GithubRepo, input.GitTagName)
+	if err != nil {
+		return model.Release{}, fmt.Errorf("generating git tag URL: %w", err)
+	}
+	input.AddGitTagURL(gitTagURL)
 
 	rls, err := model.NewRelease(input, projectID, authorUserID)
 	if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"net/url"
 
 	cryptox "release-manager/pkg/crypto"
 	"release-manager/service/model"
@@ -85,6 +86,8 @@ type githubManager interface {
 	ReadRepo(ctx context.Context, token, rawRepoURL string) (model.GithubRepo, error)
 	ReadTagsForRepo(ctx context.Context, token string, repo model.GithubRepo) ([]model.GitTag, error)
 	DeleteReleaseByTag(ctx context.Context, token string, repo model.GithubRepo, tagName string) error
+	GenerateGitTagURL(repo model.GithubRepo, tagName string) (url.URL, error)
+	TagExists(ctx context.Context, token string, repo model.GithubRepo, tagName string) (bool, error)
 }
 
 type emailSender interface {
@@ -116,7 +119,7 @@ func NewService(
 	userSvc := NewUserService(authSvc, userRepo)
 	settingsSvc := NewSettingsService(authSvc, settingsRepo)
 	projectSvc := NewProjectService(authSvc, settingsSvc, userSvc, emailSender, githubManager, projectRepo)
-	releaseSvc := NewReleaseService(authSvc, projectSvc, settingsSvc, slackNotifier, releaseRepo)
+	releaseSvc := NewReleaseService(authSvc, projectSvc, settingsSvc, slackNotifier, githubManager, releaseRepo)
 
 	return &Service{
 		Authorization: authSvc,

--- a/supabase/migrations/20240505115913_releases.sql
+++ b/supabase/migrations/20240505115913_releases.sql
@@ -3,9 +3,11 @@ CREATE TABLE public.releases (
      project_id UUID NOT NULL REFERENCES public.projects ON DELETE CASCADE,
      release_title TEXT NOT NULL,
      release_notes TEXT,
+     git_tag_name TEXT NOT NULL,
      created_by UUID REFERENCES public.users ON DELETE SET NULL,
      created_at TIMESTAMP WITH TIME ZONE NOT NULL,
-     updated_at TIMESTAMP WITH TIME ZONE NOT NULL
+     updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+     CONSTRAINT unique_git_tag_per_project UNIQUE (project_id, git_tag_name)
 );
 
 GRANT DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE

--- a/transport/errors/errormapper.go
+++ b/transport/errors/errormapper.go
@@ -31,7 +31,7 @@ func isNotFoundError(err error) bool {
 		isSvcErrorWithCode(err, svcerrors.ErrCodeEnvironmentNotFound) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeProjectInvitationNotFound) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubRepoNotFound) ||
-		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubRepoNotConfiguredForProject) ||
+		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubRepoNotSetForProject) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubIntegrationNotEnabled) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeProjectMemberNotFound) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeGithubIntegrationNotEnabled) ||
@@ -67,7 +67,8 @@ func isForbiddenError(err error) bool {
 func isConflictError(err error) bool {
 	return isSvcErrorWithCode(err, svcerrors.ErrCodeEnvironmentDuplicateName) ||
 		isSvcErrorWithCode(err, svcerrors.ErrCodeProjectInvitationAlreadyExists) ||
-		isSvcErrorWithCode(err, svcerrors.ErrCodeProjectMemberAlreadyExists)
+		isSvcErrorWithCode(err, svcerrors.ErrCodeProjectMemberAlreadyExists) ||
+		isSvcErrorWithCode(err, svcerrors.ErrCodeReleaseGitTagAlreadyUsed)
 }
 
 func isBadRequestError(err error) bool {

--- a/transport/model/release.go
+++ b/transport/model/release.go
@@ -11,7 +11,7 @@ import (
 type CreateReleaseInput struct {
 	ReleaseTitle string `json:"release_title"`
 	ReleaseNotes string `json:"release_notes"`
-	GitTagName   string `json:"git_tag"`
+	GitTagName   string `json:"git_tag_name"`
 }
 
 type UpdateReleaseInput struct {


### PR DESCRIPTION
Creating release logic updated:
- checks if git tag actually exists
- git tag is also added to release repo model and tag is saved to the db 

For now only create release func is updated, read functions (showing git tag and git tag url in response) will be added in separate PR once this one is merged.