### PR TITLE
feat: add git tag to release notification

### DIFF
--- a/service/model/release.go
+++ b/service/model/release.go
@@ -107,6 +107,8 @@ type ReleaseNotification struct {
 	ProjectName  *string
 	ReleaseTitle *string
 	ReleaseNotes *string
+	GitTagName   *string
+	GitTagURL    *url.URL
 }
 
 func NewReleaseNotification(p Project, r Release) ReleaseNotification {
@@ -122,6 +124,10 @@ func NewReleaseNotification(p Project, r Release) ReleaseNotification {
 	}
 	if p.ReleaseNotificationConfig.ShowReleaseNotes {
 		n.ReleaseNotes = &r.ReleaseNotes
+	}
+	if p.ReleaseNotificationConfig.ShowSourceCode {
+		n.GitTagName = &r.GitTagName
+		n.GitTagURL = &r.GitTagURL
 	}
 
 	return n

--- a/slack/client.go
+++ b/slack/client.go
@@ -34,6 +34,9 @@ func (c *Client) SendReleaseNotification(ctx context.Context, token, channelID s
 	if n.ReleaseNotes != nil {
 		msgOptions.AddAttachmentField("Release notes", *n.ReleaseNotes)
 	}
+	if n.GitTagName != nil && n.GitTagURL != nil {
+		msgOptions.AddAttachmentFieldWithLink("Source code", *n.GitTagURL, *n.GitTagName)
+	}
 
 	return c.sendMessage(ctx, token, channelID, msgOptions.Build())
 }

--- a/slack/message.go
+++ b/slack/message.go
@@ -1,6 +1,9 @@
 package slack
 
 import (
+	"fmt"
+	"net/url"
+
 	"github.com/slack-go/slack"
 )
 
@@ -22,6 +25,22 @@ func (b *MsgOptionsBuilder) SetMessage(msg string) *MsgOptionsBuilder {
 }
 
 func (b *MsgOptionsBuilder) AddAttachmentField(title, value string) *MsgOptionsBuilder {
+	return b.addAttachmentField(title, value)
+}
+
+func (b *MsgOptionsBuilder) AddAttachmentFieldWithLink(title string, linkURL url.URL, linkText string) *MsgOptionsBuilder {
+	// Docs: https://api.slack.com/reference/surfaces/formatting#linking
+	link := fmt.Sprintf("<%s|%s>", linkURL.String(), linkText)
+	return b.addAttachmentField(title, link)
+}
+
+func (b *MsgOptionsBuilder) addAttachmentField(title, value string) *MsgOptionsBuilder {
+	// Some of the fields can be empty (e.g. release notes).
+	// But we still want to show all fields in the message to keep the consistency and let user know that the value for field was not set.
+	if value == "" {
+		value = "-"
+	}
+
 	b.attachmentFields = append(b.attachmentFields, slack.AttachmentField{
 		Title: title,
 		Value: value,


### PR DESCRIPTION
Note: release is currently fetched from db and passed to service without git tag and git tag url but different PR will fix this.