### PR TITLE
refactor: rename param in release notification config

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -989,7 +989,7 @@ components:
             show_release_notes:
               type: boolean
               default: false
-            show_deployments:
+            show_last_deployment:
               type: boolean
               default: false
             show_source_code:

--- a/repository/model/project.go
+++ b/repository/model/project.go
@@ -24,12 +24,12 @@ type Project struct {
 }
 
 type ReleaseNotificationConfig struct {
-	Message          string `json:"message"`
-	ShowProjectName  bool   `json:"show_project_name"`
-	ShowReleaseTitle bool   `json:"show_release_title"`
-	ShowReleaseNotes bool   `json:"show_release_notes"`
-	ShowDeployments  bool   `json:"show_deployments"`
-	ShowSourceCode   bool   `json:"show_source_code"`
+	Message            string `json:"message"`
+	ShowProjectName    bool   `json:"show_project_name"`
+	ShowReleaseTitle   bool   `json:"show_release_title"`
+	ShowReleaseNotes   bool   `json:"show_release_notes"`
+	ShowLastDeployment bool   `json:"show_last_deployment"`
+	ShowSourceCode     bool   `json:"show_source_code"`
 }
 
 func ToSvcProject(p Project) (svcmodel.Project, error) {

--- a/service/model/project.go
+++ b/service/model/project.go
@@ -44,21 +44,21 @@ type UpdateProjectInput struct {
 }
 
 type ReleaseNotificationConfig struct {
-	Message          string
-	ShowProjectName  bool
-	ShowReleaseTitle bool
-	ShowReleaseNotes bool
-	ShowDeployments  bool
-	ShowSourceCode   bool
+	Message            string
+	ShowProjectName    bool
+	ShowReleaseTitle   bool
+	ShowReleaseNotes   bool
+	ShowLastDeployment bool
+	ShowSourceCode     bool
 }
 
 type UpdateReleaseNotificationConfigInput struct {
-	Message          *string
-	ShowProjectName  *bool
-	ShowReleaseTitle *bool
-	ShowReleaseNotes *bool
-	ShowDeployments  *bool
-	ShowSourceCode   *bool
+	Message            *string
+	ShowProjectName    *bool
+	ShowReleaseTitle   *bool
+	ShowReleaseNotes   *bool
+	ShowLastDeployment *bool
+	ShowSourceCode     *bool
 }
 
 func NewProject(c CreateProjectInput) (Project, error) {
@@ -129,8 +129,8 @@ func (c *ReleaseNotificationConfig) Update(u UpdateReleaseNotificationConfigInpu
 	if u.ShowReleaseNotes != nil {
 		c.ShowReleaseNotes = *u.ShowReleaseNotes
 	}
-	if u.ShowDeployments != nil {
-		c.ShowDeployments = *u.ShowDeployments
+	if u.ShowLastDeployment != nil {
+		c.ShowLastDeployment = *u.ShowLastDeployment
 	}
 	if u.ShowSourceCode != nil {
 		c.ShowSourceCode = *u.ShowSourceCode

--- a/service/model/release.go
+++ b/service/model/release.go
@@ -131,7 +131,7 @@ func NewReleaseNotification(p Project, r Release, dpl *Deployment) ReleaseNotifi
 		n.GitTagName = &r.GitTagName
 		n.GitTagURL = &r.GitTagURL
 	}
-	if p.ReleaseNotificationConfig.ShowDeployments && dpl != nil {
+	if p.ReleaseNotificationConfig.ShowLastDeployment && dpl != nil {
 		n.DeployedToEnvironment = &dpl.Environment.Name
 		n.DeployedAt = &dpl.DeployedAt
 

--- a/service/project.go
+++ b/service/project.go
@@ -531,12 +531,12 @@ func (s *ProjectService) getDefaultReleaseNotificationConfig(ctx context.Context
 	}
 
 	return model.ReleaseNotificationConfig{
-		Message:          msg,
-		ShowProjectName:  true,
-		ShowReleaseTitle: true,
-		ShowReleaseNotes: true,
-		ShowDeployments:  true,
-		ShowSourceCode:   true,
+		Message:            msg,
+		ShowProjectName:    true,
+		ShowReleaseTitle:   true,
+		ShowReleaseNotes:   true,
+		ShowLastDeployment: true,
+		ShowSourceCode:     true,
 	}, nil
 }
 

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -288,12 +288,12 @@ func TestProjectService_UpdateProject(t *testing.T) {
 				Name:           &validProjectName,
 				SlackChannelID: &slackChannelID,
 				ReleaseNotificationConfigUpdate: model.UpdateReleaseNotificationConfigInput{
-					Message:          new(string),
-					ShowProjectName:  new(bool),
-					ShowReleaseTitle: new(bool),
-					ShowReleaseNotes: new(bool),
-					ShowDeployments:  new(bool),
-					ShowSourceCode:   new(bool),
+					Message:            new(string),
+					ShowProjectName:    new(bool),
+					ShowReleaseTitle:   new(bool),
+					ShowReleaseNotes:   new(bool),
+					ShowLastDeployment: new(bool),
+					ShowSourceCode:     new(bool),
 				},
 			},
 			mockSetup: func(auth *svc.AuthorizeService, projectRepo *repo.ProjectRepository) {

--- a/transport/model/project.go
+++ b/transport/model/project.go
@@ -34,21 +34,21 @@ type Project struct {
 }
 
 type ReleaseNotificationConfig struct {
-	Message          string `json:"message"`
-	ShowProjectName  bool   `json:"show_project_name"`
-	ShowReleaseTitle bool   `json:"show_release_title"`
-	ShowReleaseNotes bool   `json:"show_release_notes"`
-	ShowDeployments  bool   `json:"show_deployments"`
-	ShowSourceCode   bool   `json:"show_source_code"`
+	Message            string `json:"message"`
+	ShowProjectName    bool   `json:"show_project_name"`
+	ShowReleaseTitle   bool   `json:"show_release_title"`
+	ShowReleaseNotes   bool   `json:"show_release_notes"`
+	ShowLastDeployment bool   `json:"show_last_deployment"`
+	ShowSourceCode     bool   `json:"show_source_code"`
 }
 
 type UpdateReleaseNotificationConfigInput struct {
-	Message          *string `json:"message"`
-	ShowProjectName  *bool   `json:"show_project_name"`
-	ShowReleaseTitle *bool   `json:"show_release_title"`
-	ShowReleaseNotes *bool   `json:"show_release_notes"`
-	ShowDeployments  *bool   `json:"show_deployments"`
-	ShowSourceCode   *bool   `json:"show_source_code"`
+	Message            *string `json:"message"`
+	ShowProjectName    *bool   `json:"show_project_name"`
+	ShowReleaseTitle   *bool   `json:"show_release_title"`
+	ShowReleaseNotes   *bool   `json:"show_release_notes"`
+	ShowLastDeployment *bool   `json:"show_deployment"`
+	ShowSourceCode     *bool   `json:"show_source_code"`
 }
 
 func ToSvcCreateProjectInput(c CreateProjectInput) svcmodel.CreateProjectInput {


### PR DESCRIPTION
Only the last deployment will be included in the Slack notification; therefore, I renamed the parameter to `ShowLastDeployment`.