### PR TITLE
feat(transport): add filtering parameters for listing deployments

### DIFF
--- a/service/model/deployment.go
+++ b/service/model/deployment.go
@@ -44,3 +44,9 @@ func NewDeployment(rls Release, env Environment, deployedByUserID uuid.UUID) Dep
 		DeployedAt:       time.Now(),
 	}
 }
+
+type DeploymentFilterParams struct {
+	ReleaseID     *uuid.UUID
+	EnvironmentID *uuid.UUID
+	LatestOnly    *bool
+}

--- a/service/model/deployment_test.go
+++ b/service/model/deployment_test.go
@@ -1,0 +1,55 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateDeploymentInput_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   CreateDeploymentInput
+		wantErr bool
+	}{
+		{
+			name: "Valid Input",
+			input: CreateDeploymentInput{
+				ReleaseID:     uuid.New(),
+				EnvironmentID: uuid.New(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid Input - No ReleaseID",
+			input: CreateDeploymentInput{
+				EnvironmentID: uuid.New(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Input - No EnvironmentID",
+			input: CreateDeploymentInput{
+				ReleaseID: uuid.New(),
+			},
+			wantErr: true,
+		},
+		{
+			name:    "Invalid Input - No ReleaseID and EnvironmentID",
+			input:   CreateDeploymentInput{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.input.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/service/release.go
+++ b/service/release.go
@@ -308,6 +308,7 @@ func (s *ReleaseService) CreateDeployment(
 
 func (s *ReleaseService) ListDeploymentsForProject(
 	ctx context.Context,
+	input model.DeploymentFilterParams,
 	projectID,
 	authUserID uuid.UUID,
 ) ([]model.Deployment, error) {
@@ -315,7 +316,7 @@ func (s *ReleaseService) ListDeploymentsForProject(
 		return nil, fmt.Errorf("authorizing project member: %w", err)
 	}
 
-	// TODO add filtering options
+	// TODO add filtering options (use model.CreateDeploymentInput)
 	dpls, err := s.repo.ListDeploymentsForProject(ctx, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("listing deployments: %w", err)

--- a/service/release_test.go
+++ b/service/release_test.go
@@ -854,7 +854,7 @@ func TestReleaseService_ListDeploymentsForProject(t *testing.T) {
 
 			tc.mockSetup(authSvc, projectSvc, releaseRepo)
 
-			_, err := service.ListDeploymentsForProject(context.TODO(), uuid.Nil, uuid.Nil)
+			_, err := service.ListDeploymentsForProject(context.TODO(), model.DeploymentFilterParams{}, uuid.Nil, uuid.Nil)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/transport/handler/deployment.go
+++ b/transport/handler/deployment.go
@@ -30,8 +30,19 @@ func (h *Handler) createDeployment(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listDeploymentsForProject(w http.ResponseWriter, r *http.Request) {
+	filterParams, err := model.ToSvcDeploymentFilterParams(
+		util.GetQueryParam(r, "release_id"),
+		util.GetQueryParam(r, "environment_id"),
+		util.GetQueryParam(r, "latest_only"),
+	)
+	if err != nil {
+		util.WriteResponseError(w, resperrors.NewBadRequestError().Wrap(err).WithMessage(err.Error()))
+		return
+	}
+
 	dpls, err := h.ReleaseSvc.ListDeploymentsForProject(
 		r.Context(),
+		filterParams,
 		util.ContextProjectID(r),
 		util.ContextAuthUserID(r),
 	)

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -58,7 +58,7 @@ type releaseService interface {
 	UpsertGithubRelease(ctx context.Context, projectID, releaseID, authUserID uuid.UUID) error
 
 	CreateDeployment(ctx context.Context, input svcmodel.CreateDeploymentInput, projectID, authUserID uuid.UUID) (svcmodel.Deployment, error)
-	ListDeploymentsForProject(ctx context.Context, projectID, authUserID uuid.UUID) ([]svcmodel.Deployment, error)
+	ListDeploymentsForProject(ctx context.Context, input svcmodel.DeploymentFilterParams, projectID, authUserID uuid.UUID) ([]svcmodel.Deployment, error)
 }
 
 type authClient interface {

--- a/transport/model/deployment.go
+++ b/transport/model/deployment.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"fmt"
+	"strconv"
 	"time"
 
 	svcmodel "release-manager/service/model"
@@ -28,6 +30,41 @@ func ToSvcCreateDeploymentInput(input CreateDeploymentInput) svcmodel.CreateDepl
 		ReleaseID:     input.ReleaseID,
 		EnvironmentID: input.EnvironmentID,
 	}
+}
+
+func ToSvcDeploymentFilterParams(releaseIDParam, environmentIDParam, latestOnlyParam string) (svcmodel.DeploymentFilterParams, error) {
+	var releaseID, environmentID *uuid.UUID
+	var latestOnly *bool
+
+	if releaseIDParam != "" {
+		id, err := uuid.Parse(releaseIDParam)
+		if err != nil {
+			return svcmodel.DeploymentFilterParams{}, fmt.Errorf("invalid uuid provided for release id: %w", err)
+		}
+		releaseID = &id
+	}
+
+	if environmentIDParam != "" {
+		id, err := uuid.Parse(environmentIDParam)
+		if err != nil {
+			return svcmodel.DeploymentFilterParams{}, fmt.Errorf("invalid uuid provided for environment id: %w", err)
+		}
+		environmentID = &id
+	}
+
+	if latestOnlyParam != "" {
+		latestOnlyValue, err := strconv.ParseBool(latestOnlyParam)
+		if err != nil {
+			return svcmodel.DeploymentFilterParams{}, fmt.Errorf("invalid boolean provided for latest only: %w", err)
+		}
+		latestOnly = &latestOnlyValue
+	}
+
+	return svcmodel.DeploymentFilterParams{
+		ReleaseID:     releaseID,
+		EnvironmentID: environmentID,
+		LatestOnly:    latestOnly,
+	}, nil
 }
 
 func ToDeployment(dpl svcmodel.Deployment) Deployment {


### PR DESCRIPTION
As suggested [here](https://www.notion.so/release-manager/Deployments-92359226704144db9c175741d53e85c4), users will be able to filter deployments by `release_id`, `environment_id`, and to show only the latest deployment.

Once this PR is merged, repository layer will be updated.