### PR TITLE
feat: add endpoint for getting project github repo

### DIFF
--- a/service/project.go
+++ b/service/project.go
@@ -181,6 +181,23 @@ func (s *ProjectService) SetGithubRepoForProject(ctx context.Context, rawRepoURL
 	return nil
 }
 
+func (s *ProjectService) GetGithubRepoForProject(ctx context.Context, projectID, authUserID uuid.UUID) (model.GithubRepo, error) {
+	if err := s.authGuard.AuthorizeProjectRoleEditor(ctx, projectID, authUserID); err != nil {
+		return model.GithubRepo{}, fmt.Errorf("authorizing project member: %w", err)
+	}
+
+	p, err := s.getProject(ctx, projectID)
+	if err != nil {
+		return model.GithubRepo{}, fmt.Errorf("getting project: %w", err)
+	}
+
+	if !p.IsGithubRepoSet() {
+		return model.GithubRepo{}, svcerrors.NewGithubRepoNotSetForProjectError()
+	}
+
+	return *p.GithubRepo, nil
+}
+
 func (s *ProjectService) CreateEnvironment(ctx context.Context, c model.CreateEnvironmentInput, authUserID uuid.UUID) (model.Environment, error) {
 	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return model.Environment{}, fmt.Errorf("authorizing user role: %w", err)

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -16,7 +16,6 @@ type projectService interface {
 	ListProjects(ctx context.Context, authUserID uuid.UUID) ([]svcmodel.Project, error)
 	UpdateProject(ctx context.Context, u svcmodel.UpdateProjectInput, projectID, authUserID uuid.UUID) (svcmodel.Project, error)
 	DeleteProject(ctx context.Context, projectID uuid.UUID, authUserID uuid.UUID) error
-	SetGithubRepoForProject(ctx context.Context, rawRepoURL string, projectID uuid.UUID, authUserID uuid.UUID) error
 
 	CreateEnvironment(ctx context.Context, c svcmodel.CreateEnvironmentInput, authUserID uuid.UUID) (svcmodel.Environment, error)
 	GetEnvironment(ctx context.Context, projectID, envID, authUserID uuid.UUID) (svcmodel.Environment, error)
@@ -24,6 +23,8 @@ type projectService interface {
 	DeleteEnvironment(ctx context.Context, projectID, envID, authUserID uuid.UUID) error
 	UpdateEnvironment(ctx context.Context, u svcmodel.UpdateEnvironmentInput, projectID, envID, authUserID uuid.UUID) (svcmodel.Environment, error)
 
+	SetGithubRepoForProject(ctx context.Context, rawRepoURL string, projectID uuid.UUID, authUserID uuid.UUID) error
+	GetGithubRepoForProject(ctx context.Context, projectID, authUserID uuid.UUID) (svcmodel.GithubRepo, error)
 	ListGithubRepoTags(ctx context.Context, projectID, authUserID uuid.UUID) ([]svcmodel.GitTag, error)
 
 	Invite(ctx context.Context, c svcmodel.CreateProjectInvitationInput, authUserID uuid.UUID) (svcmodel.ProjectInvitation, error)

--- a/transport/handler/project.go
+++ b/transport/handler/project.go
@@ -112,3 +112,17 @@ func (h *Handler) setGithubRepoForProject(w http.ResponseWriter, r *http.Request
 
 	w.WriteHeader(http.StatusNoContent)
 }
+
+func (h *Handler) getGithubRepoForProject(w http.ResponseWriter, r *http.Request) {
+	repo, err := h.ProjectSvc.GetGithubRepoForProject(
+		r.Context(),
+		util.ContextProjectID(r),
+		util.ContextAuthUserID(r),
+	)
+	if err != nil {
+		util.WriteResponseError(w, resperrors.ToError(err))
+		return
+	}
+
+	util.WriteJSONResponse(w, http.StatusOK, model.ToGithubRepo(repo))
+}

--- a/transport/handler/routes.go
+++ b/transport/handler/routes.go
@@ -61,6 +61,7 @@ func (h *Handler) setupRoutes() {
 			})
 			r.Route("/github-repo", func(r chi.Router) {
 				r.Post("/", middleware.RequireAuthUser(h.setGithubRepoForProject))
+				r.Get("/", middleware.RequireAuthUser(h.getGithubRepoForProject))
 				r.Get("/tags", middleware.RequireAuthUser(h.listGithubRepoTags))
 			})
 			r.Route("/releases", func(r chi.Router) {

--- a/transport/model/project.go
+++ b/transport/model/project.go
@@ -86,3 +86,13 @@ func ToProjects(projects []svcmodel.Project) []Project {
 
 	return p
 }
+
+type GithubRepo struct {
+	GithubRepoURL string `json:"github_repo_url"`
+}
+
+func ToGithubRepo(repo svcmodel.GithubRepo) GithubRepo {
+	return GithubRepo{
+		GithubRepoURL: repo.URL.String(),
+	}
+}


### PR DESCRIPTION
The PR adds an endpoint for retrieving a project's GitHub repository. Since users will be able to set or update a project's GitHub repository, a get endpoint is also necessary for the client to display the currently connected repository.