### PR TITLE
feat(github client): improve error handling

### DIFF
--- a/github/util/util.go
+++ b/github/util/util.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"errors"
+	"net/http"
+
+	svcerrors "release-manager/service/errors"
+
+	"github.com/google/go-github/v60/github"
+)
+
+// TranslateGithubAuthError translates GitHub auth errors to service errors
+func TranslateGithubAuthError(err error) error {
+	var githubErr *github.ErrorResponse
+	if errors.As(err, &githubErr) {
+		switch githubErr.Response.StatusCode {
+		case http.StatusUnauthorized:
+			return svcerrors.NewGithubClientUnauthorizedError().Wrap(err)
+		case http.StatusForbidden:
+			return svcerrors.NewGithubClientForbiddenError().Wrap(err)
+		}
+	}
+
+	return err
+}


### PR DESCRIPTION
All functions in the GitHub client that call the GitHub API now correctly handle 401 and 403 errors, addressing cases when an invalid GitHub token is provided or a valid token lacks the necessary permissions.