### PR TITLE
feat: add endpoint to fetch authenticated user information 

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -68,6 +68,22 @@ paths:
           $ref: '#/components/responses/ForbiddenErrorResponse'
         '422':
               $ref: '#/components/responses/UnprocesssableEntityResponse'
+  /auth/user:
+    get:
+      summary: "Get authenticated user"
+      security:
+        - bearerAuth: []
+      tags:
+        - Users
+      responses:
+        '200':
+          description: 'User fetched'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '401':
+            $ref: '#/components/responses/UnauthorizedErrorResponse'
   /admin/users:
     get:
       summary: "List organization's users"

--- a/service/authorization.go
+++ b/service/authorization.go
@@ -22,11 +22,15 @@ func NewAuthorizationService(userRepo userRepository, projectRepo projectReposit
 	}
 }
 
-func (s *AuthorizationService) AuthorizeUserRoleAdmin(ctx context.Context, userID uuid.UUID) error {
-	return s.AuthorizeUserRole(ctx, userID, model.UserRoleAdmin)
+func (s *AuthorizationService) AuthorizeUserRoleUser(ctx context.Context, userID uuid.UUID) error {
+	return s.authorizeUserRole(ctx, userID, model.UserRoleUser)
 }
 
-func (s *AuthorizationService) AuthorizeUserRole(ctx context.Context, userID uuid.UUID, role model.UserRole) error {
+func (s *AuthorizationService) AuthorizeUserRoleAdmin(ctx context.Context, userID uuid.UUID) error {
+	return s.authorizeUserRole(ctx, userID, model.UserRoleAdmin)
+}
+
+func (s *AuthorizationService) authorizeUserRole(ctx context.Context, userID uuid.UUID, role model.UserRole) error {
 	user, err := s.userRepo.Read(ctx, userID)
 	if err != nil {
 		switch {

--- a/service/mock/auth.go
+++ b/service/mock/auth.go
@@ -3,8 +3,6 @@ package mock
 import (
 	"context"
 
-	"release-manager/service/model"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 )
@@ -18,8 +16,8 @@ func (m *AuthorizeService) AuthorizeUserRoleAdmin(ctx context.Context, userID uu
 	return args.Error(0)
 }
 
-func (m *AuthorizeService) AuthorizeUserRole(ctx context.Context, userID uuid.UUID, role model.UserRole) error {
-	args := m.Called(ctx, userID, role)
+func (m *AuthorizeService) AuthorizeUserRoleUser(ctx context.Context, userID uuid.UUID) error {
+	args := m.Called(ctx, userID)
 	return args.Error(0)
 }
 

--- a/service/mock/user.go
+++ b/service/mock/user.go
@@ -13,8 +13,8 @@ type UserService struct {
 	mock.Mock
 }
 
-func (m *UserService) Get(ctx context.Context, id uuid.UUID, authUserID uuid.UUID) (model.User, error) {
-	args := m.Called(ctx, id, authUserID)
+func (m *UserService) Get(ctx context.Context, userID uuid.UUID) (model.User, error) {
+	args := m.Called(ctx, userID)
 	return args.Get(0).(model.User), args.Error(1)
 }
 

--- a/service/project.go
+++ b/service/project.go
@@ -58,7 +58,7 @@ func (s *ProjectService) CreateProject(ctx context.Context, c model.CreateProjec
 		return model.Project{}, svcerrors.NewProjectUnprocessableError().Wrap(err).WithMessage(err.Error())
 	}
 
-	u, err := s.userGetter.Get(ctx, authUserID, authUserID)
+	u, err := s.userGetter.Get(ctx, authUserID)
 	if err != nil {
 		return model.Project{}, fmt.Errorf("reading user: %w", err)
 	}

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -35,7 +35,7 @@ func TestProjectService_CreateProject(t *testing.T) {
 			mockSetup: func(auth *svc.AuthorizeService, settings *svc.SettingsService, user *svc.UserService, github *githubmock.Client, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
 				settings.On("GetDefaultReleaseMessage", mock.Anything).Return("message", nil)
-				user.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(model.User{}, nil)
+				user.On("Get", mock.Anything, mock.Anything).Return(model.User{}, nil)
 				projectRepo.On("CreateProjectWithOwner", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
@@ -49,7 +49,7 @@ func TestProjectService_CreateProject(t *testing.T) {
 			},
 			mockSetup: func(auth *svc.AuthorizeService, settings *svc.SettingsService, user *svc.UserService, github *githubmock.Client, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
-				user.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(model.User{}, nil)
+				user.On("Get", mock.Anything, mock.Anything).Return(model.User{}, nil)
 				projectRepo.On("CreateProjectWithOwner", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,

--- a/service/service.go
+++ b/service/service.go
@@ -66,7 +66,7 @@ type releaseRepository interface {
 
 type authGuard interface {
 	AuthorizeUserRoleAdmin(ctx context.Context, userID uuid.UUID) error
-	AuthorizeUserRole(ctx context.Context, userID uuid.UUID, model model.UserRole) error
+	AuthorizeUserRoleUser(ctx context.Context, userID uuid.UUID) error
 	AuthorizeProjectRoleEditor(ctx context.Context, projectID, userID uuid.UUID) error
 	AuthorizeProjectRoleViewer(ctx context.Context, projectID, userID uuid.UUID) error
 }
@@ -78,7 +78,7 @@ type settingsGetter interface {
 }
 
 type userGetter interface {
-	Get(ctx context.Context, userID, authUserID uuid.UUID) (model.User, error)
+	Get(ctx context.Context, userID uuid.UUID) (model.User, error)
 	GetByEmail(ctx context.Context, email string) (model.User, error)
 }
 

--- a/service/user.go
+++ b/service/user.go
@@ -21,12 +21,13 @@ func NewUserService(guard authGuard, repo userRepository) *UserService {
 	}
 }
 
-func (s *UserService) Get(ctx context.Context, id uuid.UUID, authUserID uuid.UUID) (model.User, error) {
-	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
+// Get retrieves a user by ID, can be accessed by the user themselves.
+func (s *UserService) Get(ctx context.Context, userID uuid.UUID) (model.User, error) {
+	if err := s.authGuard.AuthorizeUserRoleUser(ctx, userID); err != nil {
 		return model.User{}, fmt.Errorf("authorizing user role: %w", err)
 	}
 
-	u, err := s.repository.Read(ctx, id)
+	u, err := s.repository.Read(ctx, userID)
 	if err != nil {
 		return model.User{}, fmt.Errorf("reading user: %w", err)
 	}
@@ -34,6 +35,7 @@ func (s *UserService) Get(ctx context.Context, id uuid.UUID, authUserID uuid.UUI
 	return u, nil
 }
 
+// GetByEmail retrieves a user by email, this function does not require authentication!
 func (s *UserService) GetByEmail(ctx context.Context, email string) (model.User, error) {
 	u, err := s.repository.ReadByEmail(ctx, email)
 	if err != nil {
@@ -43,20 +45,36 @@ func (s *UserService) GetByEmail(ctx context.Context, email string) (model.User,
 	return u, nil
 }
 
-func (s *UserService) Delete(ctx context.Context, id uuid.UUID, authUserID uuid.UUID) error {
+// GetForAdmin retrieves a user by ID, can be accessed only by admin user.
+func (s *UserService) GetForAdmin(ctx context.Context, userID uuid.UUID, authUserID uuid.UUID) (model.User, error) {
+	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
+		return model.User{}, fmt.Errorf("authorizing user role: %w", err)
+	}
+
+	u, err := s.repository.Read(ctx, userID)
+	if err != nil {
+		return model.User{}, fmt.Errorf("reading user: %w", err)
+	}
+
+	return u, nil
+}
+
+// DeleteForAdmin deletes a user by ID, can be accessed only by admin user.
+func (s *UserService) DeleteForAdmin(ctx context.Context, userID uuid.UUID, authUserID uuid.UUID) error {
 	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return err
 	}
 
-	_, err := s.Get(ctx, id, authUserID)
+	_, err := s.GetForAdmin(ctx, userID, authUserID)
 	if err != nil {
 		return fmt.Errorf("getting user: %w", err)
 	}
 
-	return s.repository.Delete(ctx, id)
+	return s.repository.Delete(ctx, userID)
 }
 
-func (s *UserService) ListAll(ctx context.Context, authUserID uuid.UUID) ([]model.User, error) {
+// ListAllForAdmin lists all users, can be accessed only by admin user.
+func (s *UserService) ListAllForAdmin(ctx context.Context, authUserID uuid.UUID) ([]model.User, error) {
 	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
 		return nil, fmt.Errorf("authorizing user role: %w", err)
 	}

--- a/service/user_test.go
+++ b/service/user_test.go
@@ -53,7 +53,7 @@ func TestUserService_Get(t *testing.T) {
 			mockAuthSvc, mockUserRepo := tc.setupMocks()
 			userService := NewUserService(mockAuthSvc, mockUserRepo)
 
-			_, err := userService.Get(context.Background(), testUserID, authUserID)
+			_, err := userService.GetForAdmin(context.Background(), testUserID, authUserID)
 			if tc.expectErr {
 				assert.Error(t, err)
 			} else {
@@ -103,7 +103,7 @@ func TestUserService_GetAll(t *testing.T) {
 			mockAuthSvc, mockUserRepo := tc.setupMocks()
 			userService := NewUserService(mockAuthSvc, mockUserRepo)
 
-			_, err := userService.ListAll(context.Background(), authUserID)
+			_, err := userService.ListAllForAdmin(context.Background(), authUserID)
 			if tc.expectErr {
 				assert.Error(t, err)
 			} else {
@@ -165,7 +165,7 @@ func TestUserService_Delete(t *testing.T) {
 			mockAuthSvc, mockUserRepo := tc.setupMocks()
 			userService := NewUserService(mockAuthSvc, mockUserRepo)
 
-			err := userService.Delete(context.Background(), testUserID, authUserID)
+			err := userService.DeleteForAdmin(context.Background(), testUserID, authUserID)
 			if tc.expectErr {
 				assert.Error(t, err)
 			} else {

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -40,9 +40,9 @@ type projectService interface {
 }
 
 type userService interface {
-	Get(ctx context.Context, id, authUserID uuid.UUID) (svcmodel.User, error)
-	ListAll(ctx context.Context, authUserID uuid.UUID) ([]svcmodel.User, error)
-	Delete(ctx context.Context, id, authUserID uuid.UUID) error
+	GetForAdmin(ctx context.Context, userID, authUserID uuid.UUID) (svcmodel.User, error)
+	ListAllForAdmin(ctx context.Context, authUserID uuid.UUID) ([]svcmodel.User, error)
+	DeleteForAdmin(ctx context.Context, userID, authUserID uuid.UUID) error
 }
 
 type settingsService interface {

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -40,6 +40,7 @@ type projectService interface {
 }
 
 type userService interface {
+	Get(ctx context.Context, userID uuid.UUID) (svcmodel.User, error)
 	GetForAdmin(ctx context.Context, userID, authUserID uuid.UUID) (svcmodel.User, error)
 	ListAllForAdmin(ctx context.Context, authUserID uuid.UUID) ([]svcmodel.User, error)
 	DeleteForAdmin(ctx context.Context, userID, authUserID uuid.UUID) error

--- a/transport/handler/routes.go
+++ b/transport/handler/routes.go
@@ -18,11 +18,13 @@ func (h *Handler) setupRoutes() {
 	h.Mux.Use(httpx.RecoverMiddleware(slog.Default().WithGroup("recover")))
 	h.Mux.Use(middleware.Auth(h.AuthClient))
 
-	h.Mux.Get("/admin/users", middleware.RequireAuthUser(h.listUsers))
-	h.Mux.Route("/admin/users/{id}", func(r chi.Router) {
-		r.Use(middleware.HandleResourceID("id", util.ContextSetUserID))
-		r.Get("/", middleware.RequireAuthUser(h.getUser))
-		r.Delete("/", middleware.RequireAuthUser(h.deleteUser))
+	h.Mux.Route("/admin/users", func(r chi.Router) {
+		r.Get("/", middleware.RequireAuthUser(h.listUsers))
+		r.Route("/{id}", func(r chi.Router) {
+			r.Use(middleware.HandleResourceID("id", util.ContextSetUserID))
+			r.Get("/", middleware.RequireAuthUser(h.getUser))
+			r.Delete("/", middleware.RequireAuthUser(h.deleteUser))
+		})
 	})
 
 	h.Mux.Route("/projects", func(r chi.Router) {

--- a/transport/handler/routes.go
+++ b/transport/handler/routes.go
@@ -18,6 +18,8 @@ func (h *Handler) setupRoutes() {
 	h.Mux.Use(httpx.RecoverMiddleware(slog.Default().WithGroup("recover")))
 	h.Mux.Use(middleware.Auth(h.AuthClient))
 
+	h.Mux.Get("/auth/user", middleware.RequireAuthUser(h.getAuthUser))
+
 	h.Mux.Route("/admin/users", func(r chi.Router) {
 		r.Get("/", middleware.RequireAuthUser(h.listUsers))
 		r.Route("/{id}", func(r chi.Router) {

--- a/transport/handler/user.go
+++ b/transport/handler/user.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (h *Handler) getUser(w http.ResponseWriter, r *http.Request) {
-	u, err := h.UserSvc.Get(
+	u, err := h.UserSvc.GetForAdmin(
 		r.Context(),
 		util.ContextUserID(r),
 		util.ContextAuthUserID(r),
@@ -23,7 +23,7 @@ func (h *Handler) getUser(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listUsers(w http.ResponseWriter, r *http.Request) {
-	users, err := h.UserSvc.ListAll(r.Context(), util.ContextAuthUserID(r))
+	users, err := h.UserSvc.ListAllForAdmin(r.Context(), util.ContextAuthUserID(r))
 	if err != nil {
 		util.WriteResponseError(w, resperrors.ToError(err))
 		return
@@ -33,7 +33,7 @@ func (h *Handler) listUsers(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) deleteUser(w http.ResponseWriter, r *http.Request) {
-	if err := h.UserSvc.Delete(
+	if err := h.UserSvc.DeleteForAdmin(
 		r.Context(),
 		util.ContextUserID(r),
 		util.ContextAuthUserID(r),

--- a/transport/handler/user.go
+++ b/transport/handler/user.go
@@ -8,6 +8,16 @@ import (
 	"release-manager/transport/util"
 )
 
+func (h *Handler) getAuthUser(w http.ResponseWriter, r *http.Request) {
+	u, err := h.UserSvc.Get(r.Context(), util.ContextAuthUserID(r))
+	if err != nil {
+		util.WriteResponseError(w, resperrors.ToError(err))
+		return
+	}
+
+	util.WriteJSONResponse(w, http.StatusOK, model.ToUser(u))
+}
+
 func (h *Handler) getUser(w http.ResponseWriter, r *http.Request) {
 	u, err := h.UserSvc.GetForAdmin(
 		r.Context(),


### PR DESCRIPTION
User information can be accessed via endpoints provided by Supabase. While the existing endpoints provide data from `auth.users`, a new endpoint has been added to retrieve custom user parameters stored in `public.users` (such as role).

An alternative approach would be to store custom parameters also in the `auth.users` table. If this method is preferred in the future, it can be implemented using: https://github.com/supabase-community/supabase-custom-claims. This approach allows these parameters to be included directly in the JWT token.

However, in the current client implementation (using Retool), it seems easier to simply call the REST endpoint to retrieve user information rather than extracting it from the JWT token.