### PR TITLE
Revert "feat: enable to unset github repo"

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -552,7 +552,7 @@ paths:
               $ref: '#/components/responses/NotFoundErrorResponse'
   /projects/{project-id}/github-repo:
     post:
-      summary: 'Connect GitHub repo to the project'
+      summary: 'Set GitHub repo for the project'
       security:
         - bearerAuth: [ ]
       tags:
@@ -567,7 +567,7 @@ paths:
               $ref: '#/components/schemas/ProjectGithubRepoRequest'
       responses:
         '204':
-          description: 'GitHub repo connected'
+          description: 'GitHub repo set'
         '401':
           $ref: '#/components/responses/UnauthorizedErrorResponse'
         '403':
@@ -575,7 +575,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundErrorResponse'
     get:
-      summary: 'Get GitHub repo connected to the project'
+      summary: "Get project's GitHub repo"
       security:
         - bearerAuth: []
       tags:

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -552,7 +552,7 @@ paths:
               $ref: '#/components/responses/NotFoundErrorResponse'
   /projects/{project-id}/github-repo:
     post:
-      summary: 'Set GitHub repo for the project'
+      summary: 'Connect GitHub repo to the project'
       security:
         - bearerAuth: [ ]
       tags:
@@ -567,7 +567,7 @@ paths:
               $ref: '#/components/schemas/ProjectGithubRepoRequest'
       responses:
         '204':
-          description: 'GitHub repo set'
+          description: 'GitHub repo connected'
         '401':
           $ref: '#/components/responses/UnauthorizedErrorResponse'
         '403':
@@ -575,7 +575,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundErrorResponse'
     get:
-      summary: "Get project's GitHub repo"
+      summary: 'Get GitHub repo connected to the project'
       security:
         - bearerAuth: []
       tags:
@@ -595,23 +595,6 @@ paths:
             $ref: '#/components/responses/ForbiddenErrorResponse'
         '404':
             $ref: '#/components/responses/NotFoundErrorResponse'
-    delete:
-        summary: "Unset project's GitHub repo"
-        security:
-            - bearerAuth: []
-        tags:
-            - Project GitHub repo
-        parameters:
-            - $ref: '#/components/parameters/ProjectIdParam'
-        responses:
-            '204':
-              description: 'GitHub repo unset'
-            '401':
-                $ref: '#/components/responses/UnauthorizedErrorResponse'
-            '403':
-                $ref: '#/components/responses/ForbiddenErrorResponse'
-            '404':
-                $ref: '#/components/responses/NotFoundErrorResponse'
   /projects/{project-id}/github-repo/tags:
     get:
       summary: 'List GitHub repo tags'

--- a/service/model/project.go
+++ b/service/model/project.go
@@ -84,11 +84,6 @@ func (p *Project) SetGithubRepo(repo *GithubRepo) {
 	p.UpdatedAt = time.Now()
 }
 
-func (p *Project) UnsetGithubRepo() {
-	p.GithubRepo = nil
-	p.UpdatedAt = time.Now()
-}
-
 type UpdateProjectFunc func(p Project) (Project, error)
 
 func (p *Project) Update(u UpdateProjectInput) error {

--- a/service/project.go
+++ b/service/project.go
@@ -181,26 +181,6 @@ func (s *ProjectService) SetGithubRepoForProject(ctx context.Context, rawRepoURL
 	return nil
 }
 
-func (s *ProjectService) UnsetGithubRepoForProject(ctx context.Context, projectID, authUserID uuid.UUID) error {
-	if err := s.authGuard.AuthorizeProjectRoleEditor(ctx, projectID, authUserID); err != nil {
-		return fmt.Errorf("authorizing project member: %w", err)
-	}
-
-	if _, err := s.repo.UpdateProject(ctx, projectID, func(p model.Project) (model.Project, error) {
-		if !p.IsGithubRepoSet() {
-			return p, svcerrors.NewGithubRepoNotSetForProjectError()
-		}
-
-		p.UnsetGithubRepo()
-
-		return p, nil
-	}); err != nil {
-		return fmt.Errorf("unsetting project's github repo: %w", err)
-	}
-
-	return nil
-}
-
 func (s *ProjectService) GetGithubRepoForProject(ctx context.Context, projectID, authUserID uuid.UUID) (model.GithubRepo, error) {
 	if err := s.authGuard.AuthorizeProjectRoleEditor(ctx, projectID, authUserID); err != nil {
 		return model.GithubRepo{}, fmt.Errorf("authorizing project member: %w", err)

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -24,7 +24,6 @@ type projectService interface {
 	UpdateEnvironment(ctx context.Context, u svcmodel.UpdateEnvironmentInput, projectID, envID, authUserID uuid.UUID) (svcmodel.Environment, error)
 
 	SetGithubRepoForProject(ctx context.Context, rawRepoURL string, projectID uuid.UUID, authUserID uuid.UUID) error
-	UnsetGithubRepoForProject(ctx context.Context, projectID, authUserID uuid.UUID) error
 	GetGithubRepoForProject(ctx context.Context, projectID, authUserID uuid.UUID) (svcmodel.GithubRepo, error)
 	ListGithubRepoTags(ctx context.Context, projectID, authUserID uuid.UUID) ([]svcmodel.GitTag, error)
 

--- a/transport/handler/project.go
+++ b/transport/handler/project.go
@@ -113,19 +113,6 @@ func (h *Handler) setGithubRepoForProject(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *Handler) unsetGithubRepoForProject(w http.ResponseWriter, r *http.Request) {
-	if err := h.ProjectSvc.UnsetGithubRepoForProject(
-		r.Context(),
-		util.ContextProjectID(r),
-		util.ContextAuthUserID(r),
-	); err != nil {
-		util.WriteResponseError(w, resperrors.ToError(err))
-		return
-	}
-
-	w.WriteHeader(http.StatusNoContent)
-}
-
 func (h *Handler) getGithubRepoForProject(w http.ResponseWriter, r *http.Request) {
 	repo, err := h.ProjectSvc.GetGithubRepoForProject(
 		r.Context(),

--- a/transport/handler/routes.go
+++ b/transport/handler/routes.go
@@ -65,7 +65,6 @@ func (h *Handler) setupRoutes() {
 			})
 			r.Route("/github-repo", func(r chi.Router) {
 				r.Post("/", middleware.RequireAuthUser(h.setGithubRepoForProject))
-				r.Delete("/", middleware.RequireAuthUser(h.unsetGithubRepoForProject))
 				r.Get("/", middleware.RequireAuthUser(h.getGithubRepoForProject))
 				r.Get("/tags", middleware.RequireAuthUser(h.listGithubRepoTags))
 				r.Post("/release-notes", middleware.RequireAuthUser(h.generateGithubReleaseNotes))


### PR DESCRIPTION
Reverts jan-zabloudil/release-manager#155

In the current implementation, it is required to have a project connected to a GitHub repository in order to create a release because the release is linked to the GitHub repository's source code via a git tag.

However, if we allow the GitHub repository to be unset, we then face the question of how to handle releases that reference a tag in a repository that is no longer connected to the project.

The "unset github repo" function was added in the current implementation, but it raises unresolved questions and is not actually necessary in practice because a project represents a particular application with source code hosted on GitHub. And what are the possible scenarios?

- GitHub repository URL changes: In this case, the repository URL can be updated (this is a valid case that is supported in the release manager).
- Project needs a different repository: In such a case, a new project should be created, and the current one should be archived (the archive function is coming in the future).
- GitHub repository is deleted: If so, you would simply delete the project as well.

Therefore, the unset repository functionality is removed in this PR. This case will be documented in the wiki as it may be a valid scenario for refactoring in the future.
