### PR TITLE
fix: set default app settings in migration instead of using seed data

### DIFF
--- a/supabase/migrations/20240411080415_settings.sql
+++ b/supabase/migrations/20240411080415_settings.sql
@@ -5,3 +5,11 @@ CREATE TABLE public.settings (
 
 GRANT DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE, UPDATE
 ON TABLE public.settings TO service_role;
+
+-- Application expects that these settings are present, therefore default values are inserted.
+-- Settings can be changed via the application.
+INSERT INTO public.settings (key, value) VALUES
+    ('organization_name', '"Your company"'),
+    ('default_release_message', '"Hey everyone, we are thrilled to announce new release!"'),
+    ('slack', '{"enabled": false, "token": ""}'),
+    ('github', '{"enabled": false, "token": ""}');

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,5 +1,0 @@
-INSERT INTO public.settings (key, value) VALUES
-   ('organization_name', '"Your company"'),
-   ('default_release_message', '"Hey everyone, we are thrilled to announce new release!"'),
-   ('slack', '{"enabled": false, "token": ""}'),
-   ('github', '{"enabled": false, "token": ""}');


### PR DESCRIPTION
Default application settings should be set in the migration files rather than in the seed data. 

Seed data are used for fixture data during local development, and the queries in `supabase/seed.sql` are executed when running `supabase start` or `supabase db reset`.