### PR TITLE
feat: sort environments by time of creation

### DIFF
--- a/repository/query/scripts/list_environments_for_project.sql
+++ b/repository/query/scripts/list_environments_for_project.sql
@@ -1,4 +1,4 @@
 SELECT *
 FROM environments
 WHERE project_id = @projectID
-ORDER BY name
+ORDER BY created_at


### PR DESCRIPTION
**Current state:**

- Environments are currently ordered by name. 
- For example, if you have environments like dev, staging, and prod, the API returns them in the following order: dev, prod, staging.

**Desired state:**

The goal is to have these environments in a logical order: dev, staging, prod.

**Solution:**

- Proper solution would be to add an ordering column to the entity.
- This should be implemented only if there's a proven need for it. 
- For now, it makes sense to order the environments by creation time, as users typically add them in a logical sequence (e.g., dev, staging, prod).