### PR TITLE
refactor(release svc): remove unnecessary project existence checks 

### DIFF
--- a/service/mock/project.go
+++ b/service/mock/project.go
@@ -18,11 +18,6 @@ func (m *ProjectService) GetProject(ctx context.Context, projectID, authUserID u
 	return args.Get(0).(model.Project), args.Error(1)
 }
 
-func (m *ProjectService) ProjectExists(ctx context.Context, projectID, authUserID uuid.UUID) (bool, error) {
-	args := m.Called(ctx, projectID, authUserID)
-	return args.Bool(0), args.Error(1)
-}
-
 func (m *ProjectService) GetEnvironment(ctx context.Context, projectID, envID, authUserID uuid.UUID) (model.Environment, error) {
 	args := m.Called(ctx, projectID, envID, authUserID)
 	return args.Get(0).(model.Environment), args.Error(1)

--- a/service/project.go
+++ b/service/project.go
@@ -83,14 +83,6 @@ func (s *ProjectService) GetProject(ctx context.Context, projectID, authUserID u
 	return s.getProject(ctx, projectID)
 }
 
-func (s *ProjectService) ProjectExists(ctx context.Context, projectID, authUserID uuid.UUID) (bool, error) {
-	if err := s.authGuard.AuthorizeProjectRoleViewer(ctx, projectID, authUserID); err != nil {
-		return false, fmt.Errorf("authorizing project member: %w", err)
-	}
-
-	return s.projectExists(ctx, projectID)
-}
-
 func (s *ProjectService) ListProjects(ctx context.Context, authUserID uuid.UUID) ([]model.Project, error) {
 	user, err := s.authGuard.GetAuthorizedUser(ctx, authUserID)
 	if err != nil {

--- a/service/release.go
+++ b/service/release.go
@@ -114,9 +114,13 @@ func (s *ReleaseService) DeleteRelease(ctx context.Context, input model.DeleteRe
 	}
 
 	if input.DeleteGithubRelease {
-		err := s.deleteGithubRelease(ctx, projectID, releaseID, authUserID)
-		if err != nil && !svcerrors.IsGithubReleaseNotFoundError(err) {
-			return fmt.Errorf("deleting github release: %w", err)
+		if err := s.deleteGithubRelease(ctx, projectID, releaseID, authUserID); err != nil {
+			switch {
+			case svcerrors.IsGithubReleaseNotFoundError(err):
+				// If the release does not exist on GitHub, it is not an error.
+			default:
+				return fmt.Errorf("deleting github release: %w", err)
+			}
 		}
 	}
 

--- a/service/release.go
+++ b/service/release.go
@@ -170,15 +170,6 @@ func (s *ReleaseService) ListReleasesForProject(ctx context.Context, projectID, 
 	if err != nil {
 		return nil, fmt.Errorf("listing releases: %w", err)
 	}
-	if len(rls) == 0 {
-		exists, err := s.projectGetter.ProjectExists(ctx, projectID, authUserID)
-		if err != nil {
-			return nil, fmt.Errorf("checking project existence: %w", err)
-		}
-		if !exists {
-			return nil, svcerrors.NewProjectNotFoundError()
-		}
-	}
 
 	return rls, nil
 }
@@ -327,14 +318,6 @@ func (s *ReleaseService) CreateDeployment(
 		return model.Deployment{}, svcerrors.NewDeploymentUnprocessableError().Wrap(err).WithMessage(err.Error())
 	}
 
-	exists, err := s.projectGetter.ProjectExists(ctx, projectID, authUserID)
-	if err != nil {
-		return model.Deployment{}, fmt.Errorf("checking if project exists: %w", err)
-	}
-	if !exists {
-		return model.Deployment{}, svcerrors.NewProjectNotFoundError()
-	}
-
 	rls, err := s.repo.ReadRelease(ctx, projectID, input.ReleaseID)
 	if err != nil {
 		return model.Deployment{}, fmt.Errorf("getting release: %w", err)
@@ -387,16 +370,6 @@ func (s *ReleaseService) ListDeploymentsForProject(
 	dpls, err := s.repo.ListDeploymentsForProject(ctx, params, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("listing deployments: %w", err)
-	}
-
-	if len(dpls) == 0 {
-		exists, err := s.projectGetter.ProjectExists(ctx, projectID, authUserID)
-		if err != nil {
-			return nil, fmt.Errorf("checking if project exists: %w", err)
-		}
-		if !exists {
-			return nil, svcerrors.NewProjectNotFoundError()
-		}
 	}
 
 	return dpls, nil

--- a/service/release_test.go
+++ b/service/release_test.go
@@ -391,19 +391,8 @@ func TestReleaseService_ListReleasesForProject(t *testing.T) {
 			mockSetup: func(auth *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
 				auth.On("AuthorizeProjectRoleViewer", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				releaseRepo.On("ListReleasesForProject", mock.Anything, mock.Anything).Return([]model.Release{}, nil)
-				projectSvc.On("ProjectExists", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 			},
 			wantErr: false,
-		},
-		{
-			name:      "project not found",
-			projectID: uuid.New(),
-			mockSetup: func(auth *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
-				auth.On("AuthorizeProjectRoleViewer", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				releaseRepo.On("ListReleasesForProject", mock.Anything, mock.Anything).Return([]model.Release{}, nil)
-				projectSvc.On("ProjectExists", mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
-			},
-			wantErr: true,
 		},
 	}
 
@@ -832,7 +821,6 @@ func TestReleaseService_CreateDeployment(t *testing.T) {
 			},
 			mockSetup: func(authSvc *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
 				authSvc.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				projectSvc.On("ProjectExists", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 				projectSvc.On("GetEnvironment", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Environment{}, nil)
 				releaseRepo.On("CreateDeployment", mock.Anything, mock.Anything).Return(nil)
@@ -851,18 +839,6 @@ func TestReleaseService_CreateDeployment(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "project not found",
-			input: model.CreateDeploymentInput{
-				ReleaseID:     uuid.New(),
-				EnvironmentID: uuid.New(),
-			},
-			mockSetup: func(authSvc *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
-				authSvc.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				projectSvc.On("ProjectExists", mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
-			},
-			wantErr: true,
-		},
-		{
 			name: "release not found",
 			input: model.CreateDeploymentInput{
 				ReleaseID:     uuid.New(),
@@ -870,7 +846,6 @@ func TestReleaseService_CreateDeployment(t *testing.T) {
 			},
 			mockSetup: func(authSvc *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
 				authSvc.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				projectSvc.On("ProjectExists", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, svcerrors.NewReleaseNotFoundError())
 			},
 			wantErr: true,
@@ -883,7 +858,6 @@ func TestReleaseService_CreateDeployment(t *testing.T) {
 			},
 			mockSetup: func(authSvc *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
 				authSvc.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				projectSvc.On("ProjectExists", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 				projectSvc.On("GetEnvironment", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Environment{}, svcerrors.NewEnvironmentNotFoundError())
 			},
@@ -983,24 +957,6 @@ func TestReleaseService_ListDeploymentsForProject(t *testing.T) {
 				authSvc.On("AuthorizeProjectRoleViewer", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 				projectSvc.On("EnvironmentExists", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
-			},
-			wantErr: true,
-		},
-		{
-			name: "Deployments fetched successfully but no deployments found",
-			mockSetup: func(authSvc *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
-				authSvc.On("AuthorizeProjectRoleViewer", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				releaseRepo.On("ListDeploymentsForProject", mock.Anything, mock.Anything, mock.Anything).Return([]model.Deployment{}, nil)
-				projectSvc.On("ProjectExists", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
-			},
-			wantErr: false,
-		},
-		{
-			name: "Project not found",
-			mockSetup: func(authSvc *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
-				authSvc.On("AuthorizeProjectRoleViewer", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				releaseRepo.On("ListDeploymentsForProject", mock.Anything, mock.Anything, mock.Anything).Return([]model.Deployment{}, nil)
-				projectSvc.On("ProjectExists", mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
 			},
 			wantErr: true,
 		},

--- a/service/service.go
+++ b/service/service.go
@@ -86,7 +86,6 @@ type userGetter interface {
 
 type projectGetter interface {
 	GetProject(ctx context.Context, projectID uuid.UUID, authUserID uuid.UUID) (model.Project, error)
-	ProjectExists(ctx context.Context, projectID uuid.UUID, authUserID uuid.UUID) (bool, error)
 }
 
 type environmentGetter interface {


### PR DESCRIPTION
Follow up to https://github.com/jan-zabloudil/release-manager/pull/178

When authorizing a project member, if the project does not exist, the auth guard will return a ProjectNotFoundError. Therefore, it's unnecessary to check for the project's existence again. 