### PR TITLE
feat(authorization svc): add methods for authorizing release actions

### DIFF
--- a/repository/mock/release.go
+++ b/repository/mock/release.go
@@ -18,7 +18,12 @@ func (m *ReleaseRepository) CreateRelease(ctx context.Context, rls svcmodel.Rele
 	return args.Error(0)
 }
 
-func (m *ReleaseRepository) ReadRelease(ctx context.Context, projectID, releaseID uuid.UUID) (svcmodel.Release, error) {
+func (m *ReleaseRepository) ReadRelease(ctx context.Context, releaseID uuid.UUID) (svcmodel.Release, error) {
+	args := m.Called(ctx, releaseID)
+	return args.Get(0).(svcmodel.Release), args.Error(1)
+}
+
+func (m *ReleaseRepository) ReadReleaseForProject(ctx context.Context, projectID, releaseID uuid.UUID) (svcmodel.Release, error) {
 	args := m.Called(ctx, projectID, releaseID)
 	return args.Get(0).(svcmodel.Release), args.Error(1)
 }

--- a/repository/release.go
+++ b/repository/release.go
@@ -61,7 +61,11 @@ func (r *ReleaseRepository) CreateRelease(ctx context.Context, rls svcmodel.Rele
 	return nil
 }
 
-func (r *ReleaseRepository) ReadRelease(ctx context.Context, projectID, releaseID uuid.UUID) (svcmodel.Release, error) {
+func (r *ReleaseRepository) ReadRelease(ctx context.Context, releaseID uuid.UUID) (svcmodel.Release, error) {
+	return r.readRelease(ctx, r.dbpool, query.ReadRelease, pgx.NamedArgs{"releaseID": releaseID})
+}
+
+func (r *ReleaseRepository) ReadReleaseForProject(ctx context.Context, projectID, releaseID uuid.UUID) (svcmodel.Release, error) {
 	// Project ID is not needed in the query because releaseID is primary key
 	// But it is added for security reasons
 	// To make sure that the release belongs to the project that is passed from the service

--- a/service/release.go
+++ b/service/release.go
@@ -98,7 +98,7 @@ func (s *ReleaseService) GetRelease(ctx context.Context, projectID, releaseID, a
 		return model.Release{}, fmt.Errorf("authorizing project member: %w", err)
 	}
 
-	rls, err := s.repo.ReadRelease(ctx, projectID, releaseID)
+	rls, err := s.repo.ReadReleaseForProject(ctx, projectID, releaseID)
 	if err != nil {
 		return model.Release{}, fmt.Errorf("reading release: %w", err)
 	}
@@ -193,7 +193,7 @@ func (s *ReleaseService) SendReleaseNotification(ctx context.Context, projectID,
 		return fmt.Errorf("getting project: %w", err)
 	}
 
-	rls, err := s.repo.ReadRelease(ctx, projectID, releaseID)
+	rls, err := s.repo.ReadReleaseForProject(ctx, projectID, releaseID)
 	if err != nil {
 		return fmt.Errorf("reading release: %w", err)
 	}
@@ -229,7 +229,7 @@ func (s *ReleaseService) UpsertGithubRelease(ctx context.Context, projectID, rel
 		return fmt.Errorf("getting project: %w", err)
 	}
 
-	rls, err := s.repo.ReadRelease(ctx, projectID, releaseID)
+	rls, err := s.repo.ReadReleaseForProject(ctx, projectID, releaseID)
 	if err != nil {
 		return fmt.Errorf("reading release: %w", err)
 	}
@@ -256,7 +256,7 @@ func (s *ReleaseService) deleteGithubRelease(ctx context.Context, projectID, rel
 		return fmt.Errorf("getting project: %w", err)
 	}
 
-	rls, err := s.repo.ReadRelease(ctx, projectID, releaseID)
+	rls, err := s.repo.ReadReleaseForProject(ctx, projectID, releaseID)
 	if err != nil {
 		return fmt.Errorf("reading release: %w", err)
 	}
@@ -322,7 +322,7 @@ func (s *ReleaseService) CreateDeployment(
 		return model.Deployment{}, svcerrors.NewDeploymentUnprocessableError().Wrap(err).WithMessage(err.Error())
 	}
 
-	rls, err := s.repo.ReadRelease(ctx, projectID, input.ReleaseID)
+	rls, err := s.repo.ReadReleaseForProject(ctx, projectID, input.ReleaseID)
 	if err != nil {
 		return model.Deployment{}, fmt.Errorf("getting release: %w", err)
 	}
@@ -396,7 +396,7 @@ func (s *ReleaseService) getLastDeploymentForRelease(ctx context.Context, projec
 }
 
 func (s *ReleaseService) releaseExists(ctx context.Context, projectID, releaseID uuid.UUID) (bool, error) {
-	_, err := s.repo.ReadRelease(ctx, projectID, releaseID)
+	_, err := s.repo.ReadReleaseForProject(ctx, projectID, releaseID)
 	if err != nil {
 		switch {
 		case svcerrors.IsNotFoundError(err):

--- a/service/release_test.go
+++ b/service/release_test.go
@@ -188,7 +188,7 @@ func TestReleaseService_GetRelease(t *testing.T) {
 			name: "Existing release",
 			mockSetup: func(auth *svc.AuthorizationService, repo *repo.ReleaseRepository) {
 				auth.On("AuthorizeProjectRoleViewer", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				repo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
+				repo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 			},
 			wantErr: false,
 		},
@@ -196,7 +196,7 @@ func TestReleaseService_GetRelease(t *testing.T) {
 			name: "Non-existing release",
 			mockSetup: func(auth *svc.AuthorizationService, repo *repo.ReleaseRepository) {
 				auth.On("AuthorizeProjectRoleViewer", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				repo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, svcerrors.NewReleaseNotFoundError())
+				repo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, svcerrors.NewReleaseNotFoundError())
 			},
 			wantErr: true,
 		},
@@ -260,7 +260,7 @@ func TestReleaseService_DeleteRelease(t *testing.T) {
 						RepoSlug:  "repo",
 					},
 				}, nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 				github.On("DeleteReleaseByTag", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				releaseRepo.On("DeleteRelease", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
@@ -298,7 +298,7 @@ func TestReleaseService_DeleteRelease(t *testing.T) {
 				auth.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				settingsSvc.On("GetGithubToken", mock.Anything).Return("token", nil)
 				projectSvc.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, svcerrors.NewReleaseNotFoundError())
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, svcerrors.NewReleaseNotFoundError())
 			},
 			wantErr: true,
 		},
@@ -311,7 +311,7 @@ func TestReleaseService_DeleteRelease(t *testing.T) {
 				auth.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				settingsSvc.On("GetGithubToken", mock.Anything).Return("token", nil)
 				projectSvc.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 			},
 			wantErr: true,
 		},
@@ -329,7 +329,7 @@ func TestReleaseService_DeleteRelease(t *testing.T) {
 						RepoSlug:  "repo",
 					},
 				}, nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 				github.On("DeleteReleaseByTag", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(svcerrors.NewGithubReleaseNotFoundError())
 				releaseRepo.On("DeleteRelease", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
@@ -505,7 +505,7 @@ func TestReleaseService_SendReleaseNotification(t *testing.T) {
 				projectSvc.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{
 					SlackChannelID: "channel",
 				}, nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 				releaseRepo.On("ReadLastDeploymentForRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Deployment{}, nil)
 				slackClient.On("SendReleaseNotification", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
@@ -519,7 +519,7 @@ func TestReleaseService_SendReleaseNotification(t *testing.T) {
 				projectSvc.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{
 					SlackChannelID: "channel",
 				}, nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 				releaseRepo.On("ReadLastDeploymentForRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Deployment{}, svcerrors.NewDeploymentNotFoundError())
 				slackClient.On("SendReleaseNotification", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
@@ -542,7 +542,7 @@ func TestReleaseService_SendReleaseNotification(t *testing.T) {
 				projectSvc.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{
 					SlackChannelID: "channel",
 				}, nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, svcerrors.NewReleaseNotFoundError())
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, svcerrors.NewReleaseNotFoundError())
 			},
 			wantErr: true,
 		},
@@ -562,7 +562,7 @@ func TestReleaseService_SendReleaseNotification(t *testing.T) {
 				projectSvc.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{
 					SlackChannelID: "",
 				}, nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 				releaseRepo.On("ReadLastDeploymentForRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Deployment{}, nil)
 			},
 			wantErr: true,
@@ -615,7 +615,7 @@ func TestReleaseService_UpsertGithubRelease(t *testing.T) {
 						RepoSlug:  "repo",
 					},
 				}, nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 				github.On("UpsertRelease", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
@@ -648,7 +648,7 @@ func TestReleaseService_UpsertGithubRelease(t *testing.T) {
 						RepoSlug:  "repo",
 					},
 				}, nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, svcerrors.NewReleaseNotFoundError())
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, svcerrors.NewReleaseNotFoundError())
 			},
 			wantErr: true,
 		},
@@ -658,7 +658,7 @@ func TestReleaseService_UpsertGithubRelease(t *testing.T) {
 				auth.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				settingsSvc.On("GetGithubToken", mock.Anything).Return("token", nil)
 				projectSvc.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 			},
 			wantErr: true,
 		},
@@ -821,7 +821,7 @@ func TestReleaseService_CreateDeployment(t *testing.T) {
 			},
 			mockSetup: func(authSvc *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
 				authSvc.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 				projectSvc.On("GetEnvironment", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Environment{}, nil)
 				releaseRepo.On("CreateDeployment", mock.Anything, mock.Anything).Return(nil)
 			},
@@ -846,7 +846,7 @@ func TestReleaseService_CreateDeployment(t *testing.T) {
 			},
 			mockSetup: func(authSvc *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
 				authSvc.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, svcerrors.NewReleaseNotFoundError())
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, svcerrors.NewReleaseNotFoundError())
 			},
 			wantErr: true,
 		},
@@ -858,7 +858,7 @@ func TestReleaseService_CreateDeployment(t *testing.T) {
 			},
 			mockSetup: func(authSvc *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
 				authSvc.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 				projectSvc.On("GetEnvironment", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Environment{}, svcerrors.NewEnvironmentNotFoundError())
 			},
 			wantErr: true,
@@ -922,7 +922,7 @@ func TestReleaseService_ListDeploymentsForProject(t *testing.T) {
 			},
 			mockSetup: func(authSvc *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
 				authSvc.On("AuthorizeProjectRoleViewer", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 				projectSvc.On("EnvironmentExists", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 				releaseRepo.On("ListDeploymentsForProject", mock.Anything, mock.Anything, mock.Anything).Return([]model.Deployment{
 					{
@@ -943,7 +943,7 @@ func TestReleaseService_ListDeploymentsForProject(t *testing.T) {
 			},
 			mockSetup: func(authSvc *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
 				authSvc.On("AuthorizeProjectRoleViewer", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, svcerrors.NewReleaseNotFoundError())
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, svcerrors.NewReleaseNotFoundError())
 			},
 			wantErr: true,
 		},
@@ -955,7 +955,7 @@ func TestReleaseService_ListDeploymentsForProject(t *testing.T) {
 			},
 			mockSetup: func(authSvc *svc.AuthorizationService, projectSvc *svc.ProjectService, releaseRepo *repo.ReleaseRepository) {
 				authSvc.On("AuthorizeProjectRoleViewer", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				releaseRepo.On("ReadRelease", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
+				releaseRepo.On("ReadReleaseForProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Release{}, nil)
 				projectSvc.On("EnvironmentExists", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
 			},
 			wantErr: true,

--- a/service/service.go
+++ b/service/service.go
@@ -54,7 +54,8 @@ type settingsRepository interface {
 
 type releaseRepository interface {
 	CreateRelease(ctx context.Context, r model.Release) error
-	ReadRelease(ctx context.Context, projectID, releaseID uuid.UUID) (model.Release, error)
+	ReadRelease(ctx context.Context, releaseID uuid.UUID) (model.Release, error)
+	ReadReleaseForProject(ctx context.Context, projectID, releaseID uuid.UUID) (model.Release, error)
 	DeleteRelease(ctx context.Context, projectID, releaseID uuid.UUID) error
 	DeleteReleaseByGitTag(ctx context.Context, githubOwnerSlug, githubRepoSlug, gitTag string) error
 	ListReleasesForProject(ctx context.Context, projectID uuid.UUID) ([]model.Release, error)
@@ -128,7 +129,7 @@ func NewService(
 	emailSender emailSender,
 	slackNotifier slackNotifier,
 ) *Service {
-	authSvc := NewAuthorizationService(userRepo, projectRepo)
+	authSvc := NewAuthorizationService(userRepo, projectRepo, releaseRepo)
 	userSvc := NewUserService(authSvc, userRepo)
 	settingsSvc := NewSettingsService(authSvc, settingsRepo)
 	projectSvc := NewProjectService(authSvc, settingsSvc, userSvc, emailSender, githubManager, projectRepo)


### PR DESCRIPTION
This PR is related to #177.

As proposed in the issue, the project ID will no longer be part of the release endpoint routes. Therefore the authorization service must provide methods to authorize release actions based solely on the release ID and user ID.





