### PR TITLE
refactor(rest api): simplify release endpoints by removing project level

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -702,7 +702,7 @@ paths:
               $ref: '#/components/responses/UnauthorizedErrorResponse'
         '404':
               $ref: '#/components/responses/NotFoundErrorResponse'
-  /projects/{project-id}/releases/{release-id}:
+  /releases/{release-id}:
     get:
       summary: 'Get release by ID'
       security:
@@ -710,7 +710,6 @@ paths:
       tags:
         - Releases
       parameters:
-        - $ref: '#/components/parameters/ProjectIdParam'
         - $ref: '#/components/parameters/ReleaseIdParam'
       responses:
         '200':
@@ -775,7 +774,7 @@ paths:
             $ref: '#/components/responses/ForbiddenErrorResponse'
         '404':
             $ref: '#/components/responses/NotFoundErrorResponse'
-  /projects/{project-id}/releases/{release-id}/slack-notifications:
+  /releases/{release-id}/slack-notifications:
     post:
       summary: 'Send release notification to Slack'
       security:
@@ -783,7 +782,6 @@ paths:
       tags:
         - Releases
       parameters:
-        - $ref: '#/components/parameters/ProjectIdParam'
         - $ref: '#/components/parameters/ReleaseIdParam'
       responses:
         '204':
@@ -794,7 +792,7 @@ paths:
             $ref: '#/components/responses/ForbiddenErrorResponse'
         '404':
             $ref: '#/components/responses/NotFoundErrorResponse'
-  /projects/{project-id}/releases/{release-id}/github-release:
+  /releases/{release-id}/github-release:
     put:
       summary: 'Upsert GitHub release'
       security:
@@ -802,7 +800,6 @@ paths:
       tags:
         - Releases
       parameters:
-        - $ref: '#/components/parameters/ProjectIdParam'
         - $ref: '#/components/parameters/ReleaseIdParam'
       responses:
         '204':
@@ -1322,6 +1319,9 @@ components:
       type: object
       properties:
         id:
+          type: string
+          format: uuid
+        project_id:
           type: string
           format: uuid
         release_title:

--- a/repository/mock/release.go
+++ b/repository/mock/release.go
@@ -28,8 +28,8 @@ func (m *ReleaseRepository) ReadReleaseForProject(ctx context.Context, projectID
 	return args.Get(0).(svcmodel.Release), args.Error(1)
 }
 
-func (m *ReleaseRepository) DeleteRelease(ctx context.Context, projectID, releaseID uuid.UUID) error {
-	args := m.Called(ctx, projectID, releaseID)
+func (m *ReleaseRepository) DeleteRelease(ctx context.Context, releaseID uuid.UUID) error {
+	args := m.Called(ctx, releaseID)
 	return args.Error(0)
 }
 
@@ -38,8 +38,8 @@ func (m *ReleaseRepository) ListReleasesForProject(ctx context.Context, projectI
 	return args.Get(0).([]svcmodel.Release), args.Error(1)
 }
 
-func (m *ReleaseRepository) UpdateRelease(ctx context.Context, projectID, releaseID uuid.UUID, fn svcmodel.UpdateReleaseFunc) (svcmodel.Release, error) {
-	args := m.Called(ctx, projectID, releaseID, fn)
+func (m *ReleaseRepository) UpdateRelease(ctx context.Context, releaseID uuid.UUID, fn svcmodel.UpdateReleaseFunc) (svcmodel.Release, error) {
+	args := m.Called(ctx, releaseID, fn)
 	return args.Get(0).(svcmodel.Release), args.Error(1)
 }
 
@@ -53,7 +53,7 @@ func (m *ReleaseRepository) ListDeploymentsForProject(ctx context.Context, param
 	return args.Get(0).([]svcmodel.Deployment), args.Error(1)
 }
 
-func (m *ReleaseRepository) ReadLastDeploymentForRelease(ctx context.Context, projectID, releaseID uuid.UUID) (svcmodel.Deployment, error) {
+func (m *ReleaseRepository) ReadLastDeploymentForRelease(ctx context.Context, releaseID uuid.UUID) (svcmodel.Deployment, error) {
 	args := m.Called(ctx, releaseID)
 	return args.Get(0).(svcmodel.Deployment), args.Error(1)
 }

--- a/repository/query/query.go
+++ b/repository/query/query.go
@@ -10,6 +10,8 @@ var (
 	CreateRelease string
 	//go:embed scripts/read_release.sql
 	ReadRelease string
+	//go:embed scripts/read_release_for_project.sql
+	ReadReleaseForProject string
 	//go:embed scripts/delete_release.sql
 	DeleteRelease string
 	//go:embed scripts/delete_release_by_git_tag.sql

--- a/repository/query/scripts/delete_release.sql
+++ b/repository/query/scripts/delete_release.sql
@@ -1,4 +1,2 @@
 DELETE FROM releases
-WHERE
-	project_id = @projectID AND
-	id = @releaseID
+WHERE id = @releaseID

--- a/repository/query/scripts/list_releases_for_project.sql
+++ b/repository/query/scripts/list_releases_for_project.sql
@@ -2,14 +2,17 @@ SELECT
     r.*,
     p.github_owner_slug,
     p.github_repo_slug,
-    COALESCE(JSON_AGG(
-        JSON_BUILD_OBJECT(
+    COALESCE(
+        JSON_AGG(
+            JSON_BUILD_OBJECT(
                 'attachment_id', ra.attachment_id,
                 'name', ra.name,
                 'file_path', ra.file_path,
                 'created_at', ra.created_at
-        )
-    ) FILTER (WHERE ra.release_id IS NOT NULL), '[]') AS attachments
+            )
+        ) FILTER (WHERE ra.release_id IS NOT NULL),
+        '[]'
+    ) AS attachments
 FROM releases r
 JOIN projects p
     ON r.project_id = p.id

--- a/repository/query/scripts/read_last_deployment_for_release.sql
+++ b/repository/query/scripts/read_last_deployment_for_release.sql
@@ -20,7 +20,6 @@ JOIN releases r
 JOIN environments e
     ON d.environment_id = e.id
 WHERE
-    r.id = @releaseID AND
-    r.project_id = @projectID
+    r.id = @releaseID
 ORDER BY d.deployed_at DESC
 LIMIT 1

--- a/repository/query/scripts/read_release_for_project.sql
+++ b/repository/query/scripts/read_release_for_project.sql
@@ -25,8 +25,9 @@ SELECT
     COALESCE(a.attachments, '[]'::json) AS attachments
 FROM releases r
 JOIN projects p
-  ON r.project_id = p.id
+    ON r.project_id = p.id
 LEFT JOIN attachments a
-  ON a.release_id = r.id
+    ON a.release_id = r.id
 WHERE
-    r.id = @releaseID
+    r.id = @releaseID AND
+    r.project_id = @projectID

--- a/service/authorization.go
+++ b/service/authorization.go
@@ -45,18 +45,19 @@ func (s *AuthorizationService) AuthorizeProjectRoleViewer(ctx context.Context, p
 	return s.authorizeProjectRole(ctx, projectID, userID, model.ProjectRoleViewer)
 }
 
-func (s *AuthorizationService) AuthorizeReleaseWrite(ctx context.Context, releaseID, userID uuid.UUID) error {
-	// If the user has editor role within release's project, it is enough to authorize write action.
+// AuthorizeReleaseEditor authorizes the user that has editor role or higher in the release's project.
+// the function can be used to authorize release action in the release service if the project ID is not directly provided.
+func (s *AuthorizationService) AuthorizeReleaseEditor(ctx context.Context, releaseID, userID uuid.UUID) error {
 	return s.authorizeProjectRoleByRelease(ctx, releaseID, userID, model.ProjectRoleEditor)
 }
 
-func (s *AuthorizationService) AuthorizeReleaseRead(ctx context.Context, releaseID, userID uuid.UUID) error {
-	// If the user has viewer role within release's project, it is enough to authorize read action.
+// AuthorizeReleaseViewer authorizes the user that has viewer role or higher in the release's project.
+// the function can be used to authorize release action in the release service if the project ID is not directly provided.
+func (s *AuthorizationService) AuthorizeReleaseViewer(ctx context.Context, releaseID, userID uuid.UUID) error {
 	return s.authorizeProjectRoleByRelease(ctx, releaseID, userID, model.ProjectRoleViewer)
 }
 
 // authorizeProjectRoleByRelease checks if the user has the required or higher role in the project of the release.
-// the function is used to authorize actions in release service where the project ID is not directly provided.
 func (s *AuthorizationService) authorizeProjectRoleByRelease(ctx context.Context, releaseID uuid.UUID, userID uuid.UUID, role model.ProjectRole) error {
 	// Approach of reading the release and then calling authorizeProjectRole was chosen rather than
 	// having repo function ReadProjectMemberByReleaseID, because:

--- a/service/authorization_test.go
+++ b/service/authorization_test.go
@@ -303,7 +303,7 @@ func TestAuth_AuthorizeProjectRoleViewer(t *testing.T) {
 	}
 }
 
-func TestAuth_AuthorizeReleaseWrite(t *testing.T) {
+func TestAuth_AuthorizeReleaseEditor(t *testing.T) {
 	testCases := []struct {
 		name      string
 		mockSetup func(*repo.UserRepository, *repo.ProjectRepository, *repo.ReleaseRepository)
@@ -384,7 +384,7 @@ func TestAuth_AuthorizeReleaseWrite(t *testing.T) {
 
 			tc.mockSetup(userRepo, projectRepo, releaseRepo)
 
-			err := service.AuthorizeReleaseWrite(context.Background(), uuid.New(), uuid.New())
+			err := service.AuthorizeReleaseEditor(context.Background(), uuid.New(), uuid.New())
 
 			if tc.wantErr {
 				assert.Error(t, err)
@@ -399,7 +399,7 @@ func TestAuth_AuthorizeReleaseWrite(t *testing.T) {
 	}
 }
 
-func TestAuth_AuthorizeReleaseRead(t *testing.T) {
+func TestAuth_AuthorizeReleaseViewer(t *testing.T) {
 	testCases := []struct {
 		name      string
 		mockSetup func(*repo.UserRepository, *repo.ProjectRepository, *repo.ReleaseRepository)
@@ -480,7 +480,7 @@ func TestAuth_AuthorizeReleaseRead(t *testing.T) {
 
 			tc.mockSetup(userRepo, projectRepo, releaseRepo)
 
-			err := service.AuthorizeReleaseRead(context.Background(), uuid.New(), uuid.New())
+			err := service.AuthorizeReleaseViewer(context.Background(), uuid.New(), uuid.New())
 
 			if tc.wantErr {
 				assert.Error(t, err)

--- a/service/mock/authorization.go
+++ b/service/mock/authorization.go
@@ -37,3 +37,13 @@ func (m *AuthorizationService) GetAuthorizedUser(ctx context.Context, userID uui
 	args := m.Called(ctx, userID)
 	return args.Get(0).(model.User), args.Error(1)
 }
+
+func (m *AuthorizationService) AuthorizeReleaseViewer(ctx context.Context, releaseID, userID uuid.UUID) error {
+	args := m.Called(ctx, releaseID, userID)
+	return args.Error(0)
+}
+
+func (m *AuthorizationService) AuthorizeReleaseEditor(ctx context.Context, releaseID, userID uuid.UUID) error {
+	args := m.Called(ctx, releaseID, userID)
+	return args.Error(0)
+}

--- a/service/mock/project.go
+++ b/service/mock/project.go
@@ -22,8 +22,3 @@ func (m *ProjectService) GetEnvironment(ctx context.Context, projectID, envID, a
 	args := m.Called(ctx, projectID, envID, authUserID)
 	return args.Get(0).(model.Environment), args.Error(1)
 }
-
-func (m *ProjectService) EnvironmentExists(ctx context.Context, projectID, envID, authUserID uuid.UUID) (bool, error) {
-	args := m.Called(ctx, projectID, envID, authUserID)
-	return args.Bool(0), args.Error(1)
-}

--- a/service/project.go
+++ b/service/project.go
@@ -272,24 +272,6 @@ func (s *ProjectService) DeleteEnvironment(ctx context.Context, projectID, envID
 	return nil
 }
 
-func (s *ProjectService) EnvironmentExists(ctx context.Context, projectID, envID, authUserID uuid.UUID) (bool, error) {
-	if err := s.authGuard.AuthorizeProjectRoleViewer(ctx, projectID, authUserID); err != nil {
-		return false, fmt.Errorf("authorizing project member: %w", err)
-	}
-
-	_, err := s.repo.ReadEnvironment(ctx, projectID, envID)
-	if err != nil {
-		switch {
-		case svcerrors.IsNotFoundError(err):
-			return false, nil
-		default:
-			return false, fmt.Errorf("reading environment: %w", err)
-		}
-	}
-
-	return true, nil
-}
-
 func (s *ProjectService) ListGithubRepoTags(ctx context.Context, projectID, authUserID uuid.UUID) ([]model.GitTag, error) {
 	if err := s.authGuard.AuthorizeProjectRoleViewer(ctx, projectID, authUserID); err != nil {
 		return nil, fmt.Errorf("authorizing project member: %w", err)

--- a/service/service.go
+++ b/service/service.go
@@ -56,14 +56,14 @@ type releaseRepository interface {
 	CreateRelease(ctx context.Context, r model.Release) error
 	ReadRelease(ctx context.Context, releaseID uuid.UUID) (model.Release, error)
 	ReadReleaseForProject(ctx context.Context, projectID, releaseID uuid.UUID) (model.Release, error)
-	DeleteRelease(ctx context.Context, projectID, releaseID uuid.UUID) error
+	DeleteRelease(ctx context.Context, releaseID uuid.UUID) error
 	DeleteReleaseByGitTag(ctx context.Context, githubOwnerSlug, githubRepoSlug, gitTag string) error
 	ListReleasesForProject(ctx context.Context, projectID uuid.UUID) ([]model.Release, error)
-	UpdateRelease(ctx context.Context, projectID, releaseID uuid.UUID, fn model.UpdateReleaseFunc) (model.Release, error)
+	UpdateRelease(ctx context.Context, releaseID uuid.UUID, fn model.UpdateReleaseFunc) (model.Release, error)
 
 	CreateDeployment(ctx context.Context, d model.Deployment) error
 	ListDeploymentsForProject(ctx context.Context, params model.DeploymentFilterParams, projectID uuid.UUID) ([]model.Deployment, error)
-	ReadLastDeploymentForRelease(ctx context.Context, projectID, releaseID uuid.UUID) (model.Deployment, error)
+	ReadLastDeploymentForRelease(ctx context.Context, releaseID uuid.UUID) (model.Deployment, error)
 }
 
 type authGuard interface {
@@ -72,6 +72,8 @@ type authGuard interface {
 	AuthorizeUserRoleUser(ctx context.Context, userID uuid.UUID) error
 	AuthorizeProjectRoleEditor(ctx context.Context, projectID, userID uuid.UUID) error
 	AuthorizeProjectRoleViewer(ctx context.Context, projectID, userID uuid.UUID) error
+	AuthorizeReleaseEditor(ctx context.Context, releaseID, userID uuid.UUID) error
+	AuthorizeReleaseViewer(ctx context.Context, releaseID, userID uuid.UUID) error
 }
 
 type settingsGetter interface {
@@ -91,7 +93,6 @@ type projectGetter interface {
 
 type environmentGetter interface {
 	GetEnvironment(ctx context.Context, projectID, envID, authUserID uuid.UUID) (model.Environment, error)
-	EnvironmentExists(ctx context.Context, projectID, envID, authUserID uuid.UUID) (bool, error)
 }
 
 type githubManager interface {

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -55,13 +55,13 @@ type settingsService interface {
 
 type releaseService interface {
 	CreateRelease(ctx context.Context, input svcmodel.CreateReleaseInput, projectID, authUserID uuid.UUID) (svcmodel.Release, error)
-	GetRelease(ctx context.Context, projectID, releaseID, authUserID uuid.UUID) (svcmodel.Release, error)
-	DeleteRelease(ctx context.Context, input svcmodel.DeleteReleaseInput, projectID, releaseID, authUserID uuid.UUID) error
+	GetRelease(ctx context.Context, releaseID, authUserID uuid.UUID) (svcmodel.Release, error)
+	DeleteRelease(ctx context.Context, input svcmodel.DeleteReleaseInput, releaseID, authUserID uuid.UUID) error
 	DeleteReleaseByGitTag(ctx context.Context, githubOwnerSlug, githubRepoSlug, gitTag string) error
-	UpdateRelease(ctx context.Context, input svcmodel.UpdateReleaseInput, projectID, releaseID, authUserID uuid.UUID) (svcmodel.Release, error)
+	UpdateRelease(ctx context.Context, input svcmodel.UpdateReleaseInput, releaseID, authUserID uuid.UUID) (svcmodel.Release, error)
 	ListReleasesForProject(ctx context.Context, projectID, authUserID uuid.UUID) ([]svcmodel.Release, error)
-	SendReleaseNotification(ctx context.Context, projectID, releaseID, authUserID uuid.UUID) error
-	UpsertGithubRelease(ctx context.Context, projectID, releaseID, authUserID uuid.UUID) error
+	SendReleaseNotification(ctx context.Context, releaseID, authUserID uuid.UUID) error
+	UpsertGithubRelease(ctx context.Context, releaseID, authUserID uuid.UUID) error
 	GenerateGithubReleaseNotes(ctx context.Context, input svcmodel.GithubGeneratedReleaseNotesInput, projectID, authUserID uuid.UUID) (svcmodel.GithubGeneratedReleaseNotes, error)
 
 	CreateDeployment(ctx context.Context, input svcmodel.CreateDeploymentInput, projectID, authUserID uuid.UUID) (svcmodel.Deployment, error)

--- a/transport/handler/release.go
+++ b/transport/handler/release.go
@@ -32,7 +32,6 @@ func (h *Handler) createRelease(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) getRelease(w http.ResponseWriter, r *http.Request) {
 	rls, err := h.ReleaseSvc.GetRelease(
 		r.Context(),
-		util.ContextProjectID(r),
 		util.ContextReleaseID(r),
 		util.ContextAuthUserID(r),
 	)
@@ -54,7 +53,6 @@ func (h *Handler) deleteRelease(w http.ResponseWriter, r *http.Request) {
 	if err := h.ReleaseSvc.DeleteRelease(
 		r.Context(),
 		model.ToSvcDeleteReleaseInput(input),
-		util.ContextProjectID(r),
 		util.ContextReleaseID(r),
 		util.ContextAuthUserID(r),
 	); err != nil {
@@ -89,7 +87,6 @@ func (h *Handler) updateRelease(w http.ResponseWriter, r *http.Request) {
 	rls, err := h.ReleaseSvc.UpdateRelease(
 		r.Context(),
 		model.ToSvcUpdateReleaseInput(input),
-		util.ContextProjectID(r),
 		util.ContextReleaseID(r),
 		util.ContextAuthUserID(r),
 	)
@@ -104,7 +101,6 @@ func (h *Handler) updateRelease(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) sendReleaseNotification(w http.ResponseWriter, r *http.Request) {
 	if err := h.ReleaseSvc.SendReleaseNotification(
 		r.Context(),
-		util.ContextProjectID(r),
 		util.ContextReleaseID(r),
 		util.ContextAuthUserID(r),
 	); err != nil {
@@ -118,7 +114,6 @@ func (h *Handler) sendReleaseNotification(w http.ResponseWriter, r *http.Request
 func (h *Handler) upsertGithubRelease(w http.ResponseWriter, r *http.Request) {
 	if err := h.ReleaseSvc.UpsertGithubRelease(
 		r.Context(),
-		util.ContextProjectID(r),
 		util.ContextReleaseID(r),
 		util.ContextAuthUserID(r),
 	); err != nil {

--- a/transport/handler/routes.go
+++ b/transport/handler/routes.go
@@ -72,14 +72,6 @@ func (h *Handler) setupRoutes() {
 			r.Route("/releases", func(r chi.Router) {
 				r.Get("/", middleware.RequireAuthUser(h.listReleases))
 				r.Post("/", middleware.RequireAuthUser(h.createRelease))
-				r.Route("/{release_id}", func(r chi.Router) {
-					r.Use(middleware.SetResourceUUIDToContext("release_id", util.ContextSetReleaseID))
-					r.Get("/", middleware.RequireAuthUser(h.getRelease))
-					r.Patch("/", middleware.RequireAuthUser(h.updateRelease))
-					r.Delete("/", middleware.RequireAuthUser(h.deleteRelease))
-					r.Post("/slack-notifications", middleware.RequireAuthUser(h.sendReleaseNotification))
-					r.Put("/github-release", middleware.RequireAuthUser(h.upsertGithubRelease))
-				})
 			})
 			r.Route("/deployments", func(r chi.Router) {
 				r.Post("/", middleware.RequireAuthUser(h.createDeployment))
@@ -92,6 +84,15 @@ func (h *Handler) setupRoutes() {
 		r.Use(middleware.HandleInvitationToken)
 		r.Get("/accept", h.acceptInvitation)
 		r.Get("/reject", h.rejectInvitation)
+	})
+
+	h.Mux.Route("/releases/{release_id}", func(r chi.Router) {
+		r.Use(middleware.SetResourceUUIDToContext("release_id", util.ContextSetReleaseID))
+		r.Get("/", middleware.RequireAuthUser(h.getRelease))
+		r.Patch("/", middleware.RequireAuthUser(h.updateRelease))
+		r.Delete("/", middleware.RequireAuthUser(h.deleteRelease))
+		r.Post("/slack-notifications", middleware.RequireAuthUser(h.sendReleaseNotification))
+		r.Put("/github-release", middleware.RequireAuthUser(h.upsertGithubRelease))
 	})
 
 	h.Mux.Route("/settings", func(r chi.Router) {

--- a/transport/model/release.go
+++ b/transport/model/release.go
@@ -25,6 +25,7 @@ type DeleteReleaseInput struct {
 
 type Release struct {
 	ID           uuid.UUID           `json:"id"`
+	ProjectID    uuid.UUID           `json:"project_id"`
 	ReleaseTitle string              `json:"release_title"`
 	ReleaseNotes string              `json:"release_notes"`
 	GitTagName   string              `json:"git_tag_name"`
@@ -64,6 +65,7 @@ func ToSvcDeleteReleaseInput(r DeleteReleaseInput) svcmodel.DeleteReleaseInput {
 func ToRelease(r svcmodel.Release) Release {
 	return Release{
 		ID:           r.ID,
+		ProjectID:    r.ProjectID,
 		ReleaseTitle: r.ReleaseTitle,
 		ReleaseNotes: r.ReleaseNotes,
 		GitTagName:   r.GitTagName,


### PR DESCRIPTION
BREAKING CHANGE: All endpoints for accessing a single release no longer include the project in the path. This change requires updating any clients relying on the previous endpoint structure.

Additionally, the release service has been refactored for improved maintainability.