### PR TITLE
feat(project svc): omit object return when perfoming updates

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -340,12 +340,8 @@ paths:
             schema:
               $ref: '#/components/schemas/EnvironmentRequest'
       responses:
-        '200':
+        '204':
           description: 'Environment updated'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EnvironmentResponse'
         '401':
           $ref: '#/components/responses/UnauthorizedErrorResponse'
         '403':

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -511,12 +511,8 @@ paths:
                 project_role:
                   $ref: '#/components/schemas/ProjectMemberRole'
       responses:
-        '200':
+        '204':
           description: 'Member role updated'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProjectMemberResponse'
         '400':
             $ref: '#/components/responses/BadRequestErrorResponse'
         '401':

--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -226,12 +226,8 @@ paths:
             schema:
               $ref: '#/components/schemas/ProjectRequest'
       responses:
-        '200':
+        '204':
           description: 'Project updated'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProjectResponse'
         '401':
               $ref: '#/components/responses/UnauthorizedErrorResponse'
         '403':

--- a/repository/mock/project.go
+++ b/repository/mock/project.go
@@ -129,7 +129,7 @@ func (m *ProjectRepository) DeleteMember(ctx context.Context, projectID, userID 
 	return args.Error(0)
 }
 
-func (m *ProjectRepository) UpdateMemberRole(ctx context.Context, projectID, userID uuid.UUID, fn svcmodel.UpdateProjectMemberFunc) (svcmodel.ProjectMember, error) {
+func (m *ProjectRepository) UpdateMemberRole(ctx context.Context, projectID, userID uuid.UUID, fn svcmodel.UpdateProjectMemberFunc) error {
 	args := m.Called(ctx, projectID, userID, fn)
-	return args.Get(0).(svcmodel.ProjectMember), args.Error(1)
+	return args.Error(0)
 }

--- a/repository/mock/project.go
+++ b/repository/mock/project.go
@@ -39,9 +39,9 @@ func (m *ProjectRepository) DeleteProject(ctx context.Context, id uuid.UUID) err
 	return args.Error(0)
 }
 
-func (m *ProjectRepository) UpdateProject(ctx context.Context, projectID uuid.UUID, fn svcmodel.UpdateProjectFunc) (svcmodel.Project, error) {
+func (m *ProjectRepository) UpdateProject(ctx context.Context, projectID uuid.UUID, fn svcmodel.UpdateProjectFunc) error {
 	args := m.Called(ctx, projectID, fn)
-	return args.Get(0).(svcmodel.Project), args.Error(1)
+	return args.Error(0)
 }
 
 func (m *ProjectRepository) CreateEnvironment(ctx context.Context, e svcmodel.Environment) error {

--- a/repository/mock/project.go
+++ b/repository/mock/project.go
@@ -64,9 +64,9 @@ func (m *ProjectRepository) DeleteEnvironment(ctx context.Context, projectID, en
 	return args.Error(0)
 }
 
-func (m *ProjectRepository) UpdateEnvironment(ctx context.Context, projectID, envID uuid.UUID, fn svcmodel.UpdateEnvironmentFunc) (svcmodel.Environment, error) {
+func (m *ProjectRepository) UpdateEnvironment(ctx context.Context, projectID, envID uuid.UUID, fn svcmodel.UpdateEnvironmentFunc) error {
 	args := m.Called(ctx, projectID, envID, fn)
-	return args.Get(0).(svcmodel.Environment), args.Error(1)
+	return args.Error(0)
 }
 
 func (m *ProjectRepository) CreateInvitation(ctx context.Context, i svcmodel.ProjectInvitation) error {

--- a/repository/project.go
+++ b/repository/project.go
@@ -467,9 +467,9 @@ func (r *ProjectRepository) UpdateMemberRole(
 	projectID,
 	userID uuid.UUID,
 	fn svcmodel.UpdateProjectMemberFunc,
-) (m svcmodel.ProjectMember, err error) {
-	err = util.RunTransaction(ctx, r.dbpool, func(tx pgx.Tx) error {
-		m, err = r.readMember(ctx, tx, query.AppendForUpdate(query.ReadMember), pgx.NamedArgs{
+) error {
+	return util.RunTransaction(ctx, r.dbpool, func(tx pgx.Tx) error {
+		m, err := r.readMember(ctx, tx, query.AppendForUpdate(query.ReadMember), pgx.NamedArgs{
 			"projectID": projectID,
 			"userID":    userID,
 		})
@@ -482,7 +482,7 @@ func (r *ProjectRepository) UpdateMemberRole(
 			return err
 		}
 
-		if _, err = tx.Exec(ctx, query.UpdateMember, pgx.NamedArgs{
+		if _, err := tx.Exec(ctx, query.UpdateMember, pgx.NamedArgs{
 			"projectID":   m.ProjectID,
 			"userID":      m.User.ID,
 			"projectRole": m.ProjectRole,
@@ -493,12 +493,6 @@ func (r *ProjectRepository) UpdateMemberRole(
 
 		return err
 	})
-
-	if err != nil {
-		return svcmodel.ProjectMember{}, err
-	}
-
-	return m, nil
 }
 
 func toUpdateProjectArgs(p svcmodel.Project) pgx.NamedArgs {

--- a/repository/project.go
+++ b/repository/project.go
@@ -216,9 +216,9 @@ func (r *ProjectRepository) UpdateEnvironment(
 	projectID,
 	envID uuid.UUID,
 	fn svcmodel.UpdateEnvironmentFunc,
-) (env svcmodel.Environment, err error) {
-	err = util.RunTransaction(ctx, r.dbpool, func(tx pgx.Tx) error {
-		env, err = r.readEnvironment(ctx, r.dbpool, query.AppendForUpdate(query.ReadEnvironment), projectID, envID)
+) error {
+	return util.RunTransaction(ctx, r.dbpool, func(tx pgx.Tx) error {
+		env, err := r.readEnvironment(ctx, r.dbpool, query.AppendForUpdate(query.ReadEnvironment), projectID, envID)
 		if err != nil {
 			return fmt.Errorf("reading environment: %w", err)
 		}
@@ -243,12 +243,6 @@ func (r *ProjectRepository) UpdateEnvironment(
 
 		return nil
 	})
-
-	if err != nil {
-		return svcmodel.Environment{}, err
-	}
-
-	return env, nil
 }
 
 func (r *ProjectRepository) CreateInvitation(ctx context.Context, i svcmodel.ProjectInvitation) error {

--- a/service/project.go
+++ b/service/project.go
@@ -225,23 +225,22 @@ func (s *ProjectService) UpdateEnvironment(
 	projectID,
 	envID,
 	authUserID uuid.UUID,
-) (model.Environment, error) {
+) error {
 	if err := s.authGuard.AuthorizeProjectRoleEditor(ctx, projectID, authUserID); err != nil {
-		return model.Environment{}, fmt.Errorf("authorizing project member: %w", err)
+		return fmt.Errorf("authorizing project member: %w", err)
 	}
 
-	env, err := s.repo.UpdateEnvironment(ctx, projectID, envID, func(e model.Environment) (model.Environment, error) {
+	if err := s.repo.UpdateEnvironment(ctx, projectID, envID, func(e model.Environment) (model.Environment, error) {
 		if err := e.Update(input); err != nil {
 			return model.Environment{}, svcerrors.NewEnvironmentUnprocessableError().Wrap(err).WithMessage(err.Error())
 		}
 
 		return e, nil
-	})
-	if err != nil {
-		return model.Environment{}, fmt.Errorf("updating the environment: %w", err)
+	}); err != nil {
+		return fmt.Errorf("updating the environment: %w", err)
 	}
 
-	return env, nil
+	return nil
 }
 
 func (s *ProjectService) ListEnvironments(ctx context.Context, projectID, authUserID uuid.UUID) ([]model.Environment, error) {

--- a/service/project.go
+++ b/service/project.go
@@ -487,23 +487,22 @@ func (s *ProjectService) UpdateMemberRole(
 	projectID,
 	userID,
 	authUserID uuid.UUID,
-) (model.ProjectMember, error) {
+) error {
 	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
-		return model.ProjectMember{}, fmt.Errorf("authorizing user role: %w", err)
+		return fmt.Errorf("authorizing user role: %w", err)
 	}
 
-	m, err := s.repo.UpdateMemberRole(ctx, projectID, userID, func(m model.ProjectMember) (model.ProjectMember, error) {
+	if err := s.repo.UpdateMemberRole(ctx, projectID, userID, func(m model.ProjectMember) (model.ProjectMember, error) {
 		if err := m.UpdateProjectRole(newRole); err != nil {
 			return model.ProjectMember{}, svcerrors.NewProjectMemberUnprocessableError().Wrap(err).WithMessage(err.Error())
 		}
 
 		return m, nil
-	})
-	if err != nil {
-		return model.ProjectMember{}, fmt.Errorf("updating member role: %w", err)
+	}); err != nil {
+		return fmt.Errorf("updating member role: %w", err)
 	}
 
-	return m, nil
+	return nil
 }
 
 func (s *ProjectService) getProject(ctx context.Context, projectID uuid.UUID) (model.Project, error) {

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -1182,7 +1182,7 @@ func TestProjectService_UpdateMemberRole(t *testing.T) {
 			projectID: uuid.New(),
 			mockSetup: func(auth *svc.AuthorizationService, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
-				projectRepo.On("UpdateMemberRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectMember{}, svcerrors.NewProjectMemberNotFoundError())
+				projectRepo.On("UpdateMemberRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(svcerrors.NewProjectMemberNotFoundError())
 			},
 			wantErr: true,
 		},
@@ -1192,7 +1192,7 @@ func TestProjectService_UpdateMemberRole(t *testing.T) {
 			projectID: uuid.New(),
 			mockSetup: func(auth *svc.AuthorizationService, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
-				projectRepo.On("UpdateMemberRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.ProjectMember{}, nil)
+				projectRepo.On("UpdateMemberRole", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -1210,7 +1210,7 @@ func TestProjectService_UpdateMemberRole(t *testing.T) {
 
 			tc.mockSetup(authSvc, projectRepo)
 
-			_, err := service.UpdateMemberRole(context.Background(), tc.newRole, tc.projectID, uuid.New(), uuid.New())
+			err := service.UpdateMemberRole(context.Background(), tc.newRole, tc.projectID, uuid.New(), uuid.New())
 
 			if tc.wantErr {
 				assert.Error(t, err)

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -495,7 +495,7 @@ func TestProjectService_UpdateEnvironment(t *testing.T) {
 			},
 			mockSetup: func(auth *svc.AuthorizationService, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				projectRepo.On("UpdateEnvironment", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Environment{}, nil)
+				projectRepo.On("UpdateEnvironment", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -504,7 +504,7 @@ func TestProjectService_UpdateEnvironment(t *testing.T) {
 			envUpdate: model.UpdateEnvironmentInput{},
 			mockSetup: func(auth *svc.AuthorizationService, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				projectRepo.On("UpdateEnvironment", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.Environment{}, svcerrors.NewEnvironmentNotFoundError())
+				projectRepo.On("UpdateEnvironment", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(svcerrors.NewEnvironmentNotFoundError())
 			},
 			wantErr: true,
 		},
@@ -522,7 +522,7 @@ func TestProjectService_UpdateEnvironment(t *testing.T) {
 
 			tc.mockSetup(authSvc, projectRepo)
 
-			_, err := service.UpdateEnvironment(context.Background(), tc.envUpdate, uuid.New(), uuid.New(), uuid.UUID{})
+			err := service.UpdateEnvironment(context.Background(), tc.envUpdate, uuid.New(), uuid.New(), uuid.UUID{})
 
 			if tc.wantErr {
 				assert.Error(t, err)

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -300,7 +300,7 @@ func TestProjectService_UpdateProject(t *testing.T) {
 			},
 			mockSetup: func(auth *svc.AuthorizationService, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				projectRepo.On("UpdateProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
+				projectRepo.On("UpdateProject", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -308,7 +308,7 @@ func TestProjectService_UpdateProject(t *testing.T) {
 			name: "Invalid project update",
 			mockSetup: func(auth *svc.AuthorizationService, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				projectRepo.On("UpdateProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, svcerrors.NewProjectUnprocessableError())
+				projectRepo.On("UpdateProject", mock.Anything, mock.Anything, mock.Anything).Return(svcerrors.NewProjectUnprocessableError())
 			},
 			wantErr: true,
 		},
@@ -317,7 +317,7 @@ func TestProjectService_UpdateProject(t *testing.T) {
 			update: model.UpdateProjectInput{},
 			mockSetup: func(auth *svc.AuthorizationService, projectRepo *repo.ProjectRepository) {
 				auth.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				projectRepo.On("UpdateProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, svcerrors.NewProjectNotFoundError())
+				projectRepo.On("UpdateProject", mock.Anything, mock.Anything, mock.Anything).Return(svcerrors.NewProjectNotFoundError())
 			},
 			wantErr: true,
 		},
@@ -335,7 +335,7 @@ func TestProjectService_UpdateProject(t *testing.T) {
 
 			tc.mockSetup(authSvc, projectRepo)
 
-			_, err := service.UpdateProject(context.Background(), tc.update, uuid.New(), uuid.New())
+			err := service.UpdateProject(context.Background(), tc.update, uuid.New(), uuid.New())
 
 			if tc.wantErr {
 				assert.Error(t, err)
@@ -1236,7 +1236,7 @@ func TestProjectService_SetGithubRepoForProject(t *testing.T) {
 				auth.On("AuthorizeProjectRoleEditor", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				settingsSvc.On("GetGithubToken", mock.Anything).Return("token", nil)
 				githubClient.On("ReadRepo", mock.Anything, mock.Anything, mock.Anything).Return(model.GithubRepo{}, nil)
-				projectRepo.On("UpdateProject", mock.Anything, mock.Anything, mock.Anything).Return(model.Project{}, nil)
+				projectRepo.On("UpdateProject", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
 		},

--- a/service/service.go
+++ b/service/service.go
@@ -20,7 +20,7 @@ type projectRepository interface {
 
 	CreateEnvironment(ctx context.Context, env model.Environment) error
 	ReadEnvironment(ctx context.Context, projectID, envID uuid.UUID) (model.Environment, error)
-	UpdateEnvironment(ctx context.Context, projectID, envID uuid.UUID, fn model.UpdateEnvironmentFunc) (model.Environment, error)
+	UpdateEnvironment(ctx context.Context, projectID, envID uuid.UUID, fn model.UpdateEnvironmentFunc) error
 	DeleteEnvironment(ctx context.Context, projectID, envID uuid.UUID) error
 	ListEnvironmentsForProject(ctx context.Context, projectID uuid.UUID) ([]model.Environment, error)
 

--- a/service/service.go
+++ b/service/service.go
@@ -16,7 +16,7 @@ type projectRepository interface {
 	ListProjects(ctx context.Context) ([]model.Project, error)
 	ListProjectsForUser(ctx context.Context, userID uuid.UUID) ([]model.Project, error)
 	DeleteProject(ctx context.Context, id uuid.UUID) error
-	UpdateProject(ctx context.Context, projectID uuid.UUID, fn model.UpdateProjectFunc) (model.Project, error)
+	UpdateProject(ctx context.Context, projectID uuid.UUID, fn model.UpdateProjectFunc) error
 
 	CreateEnvironment(ctx context.Context, env model.Environment) error
 	ReadEnvironment(ctx context.Context, projectID, envID uuid.UUID) (model.Environment, error)

--- a/service/service.go
+++ b/service/service.go
@@ -37,7 +37,7 @@ type projectRepository interface {
 	ReadMember(ctx context.Context, projectID, userID uuid.UUID) (model.ProjectMember, error)
 	ReadMemberByEmail(ctx context.Context, projectID uuid.UUID, email string) (model.ProjectMember, error)
 	DeleteMember(ctx context.Context, projectID, userID uuid.UUID) error
-	UpdateMemberRole(ctx context.Context, projectID, userID uuid.UUID, fn model.UpdateProjectMemberFunc) (model.ProjectMember, error)
+	UpdateMemberRole(ctx context.Context, projectID, userID uuid.UUID, fn model.UpdateProjectMemberFunc) error
 }
 
 type userRepository interface {

--- a/transport/handler/environment.go
+++ b/transport/handler/environment.go
@@ -35,19 +35,18 @@ func (h *Handler) updateEnvironment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	env, err := h.ProjectSvc.UpdateEnvironment(
+	if err := h.ProjectSvc.UpdateEnvironment(
 		r.Context(),
 		model.ToSvcUpdateEnvironmentInput(req),
 		util.ContextProjectID(r),
 		util.ContextEnvironmentID(r),
 		util.ContextAuthUserID(r),
-	)
-	if err != nil {
+	); err != nil {
 		util.WriteResponseError(w, resperrors.ToError(err))
 		return
 	}
 
-	util.WriteJSONResponse(w, http.StatusOK, model.ToEnvironment(env))
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) getEnvironment(w http.ResponseWriter, r *http.Request) {

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -22,7 +22,7 @@ type projectService interface {
 	GetEnvironment(ctx context.Context, projectID, envID, authUserID uuid.UUID) (svcmodel.Environment, error)
 	ListEnvironments(ctx context.Context, projectID, authUserID uuid.UUID) ([]svcmodel.Environment, error)
 	DeleteEnvironment(ctx context.Context, projectID, envID, authUserID uuid.UUID) error
-	UpdateEnvironment(ctx context.Context, u svcmodel.UpdateEnvironmentInput, projectID, envID, authUserID uuid.UUID) (svcmodel.Environment, error)
+	UpdateEnvironment(ctx context.Context, u svcmodel.UpdateEnvironmentInput, projectID, envID, authUserID uuid.UUID) error
 
 	SetGithubRepoForProject(ctx context.Context, rawRepoURL string, projectID uuid.UUID, authUserID uuid.UUID) error
 	GetGithubRepoForProject(ctx context.Context, projectID, authUserID uuid.UUID) (svcmodel.GithubRepo, error)

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -15,7 +15,7 @@ type projectService interface {
 	CreateProject(ctx context.Context, c svcmodel.CreateProjectInput, authUserID uuid.UUID) (svcmodel.Project, error)
 	GetProject(ctx context.Context, projectID uuid.UUID, authUserID uuid.UUID) (svcmodel.Project, error)
 	ListProjects(ctx context.Context, authUserID uuid.UUID) ([]svcmodel.Project, error)
-	UpdateProject(ctx context.Context, u svcmodel.UpdateProjectInput, projectID, authUserID uuid.UUID) (svcmodel.Project, error)
+	UpdateProject(ctx context.Context, u svcmodel.UpdateProjectInput, projectID, authUserID uuid.UUID) error
 	DeleteProject(ctx context.Context, projectID uuid.UUID, authUserID uuid.UUID) error
 
 	CreateEnvironment(ctx context.Context, c svcmodel.CreateEnvironmentInput, authUserID uuid.UUID) (svcmodel.Environment, error)

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -37,7 +37,7 @@ type projectService interface {
 	ListMembersForProject(ctx context.Context, projectID, authUserID uuid.UUID) ([]svcmodel.ProjectMember, error)
 	ListMembersForUser(ctx context.Context, authUserID uuid.UUID) ([]svcmodel.ProjectMember, error)
 	DeleteMember(ctx context.Context, projectID, userID, authUserID uuid.UUID) error
-	UpdateMemberRole(ctx context.Context, newRole svcmodel.ProjectRole, projectID, userID, authUserID uuid.UUID) (svcmodel.ProjectMember, error)
+	UpdateMemberRole(ctx context.Context, newRole svcmodel.ProjectRole, projectID, userID, authUserID uuid.UUID) error
 }
 
 type userService interface {

--- a/transport/handler/project.go
+++ b/transport/handler/project.go
@@ -56,18 +56,17 @@ func (h *Handler) updateProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	p, err := h.ProjectSvc.UpdateProject(
+	if err := h.ProjectSvc.UpdateProject(
 		r.Context(),
 		model.ToSvcUpdateProjectInput(req),
 		util.ContextProjectID(r),
 		util.ContextAuthUserID(r),
-	)
-	if err != nil {
+	); err != nil {
 		util.WriteResponseError(w, resperrors.ToError(err))
 		return
 	}
 
-	util.WriteJSONResponse(w, http.StatusOK, model.ToProject(p))
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) deleteProject(w http.ResponseWriter, r *http.Request) {

--- a/transport/handler/project_member.go
+++ b/transport/handler/project_member.go
@@ -41,17 +41,16 @@ func (h *Handler) updateMemberRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	m, err := h.ProjectSvc.UpdateMemberRole(
+	if err := h.ProjectSvc.UpdateMemberRole(
 		r.Context(),
 		svcmodel.ProjectRole(input.ProjectRole),
 		util.ContextProjectID(r),
 		util.ContextUserID(r),
 		util.ContextAuthUserID(r),
-	)
-	if err != nil {
+	); err != nil {
 		util.WriteResponseError(w, resperrors.ToError(err))
 		return
 	}
 
-	util.WriteJSONResponse(w, http.StatusOK, model.ToProjectMember(m))
+	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
The client does not need the endpoints to return the updated entity when calling PATCH requests. 

Also, the implementation is simpler when the service—especially the repository function—doesn't return the updated entity and follows the command/query principle...