### PR TITLE
feat(settings svc): omit object return on settings update

### DIFF
--- a/api-doc.yaml
+++ b/api-doc.yaml
@@ -54,12 +54,8 @@ paths:
             schema:
               $ref: '#/components/schemas/Settings'
       responses:
-        '200':
+        '204':
           description: 'Settings updated'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Settings'
         '400':
           $ref: '#/components/responses/BadRequestErrorResponse'
         '401':

--- a/repository/mock/settings.go
+++ b/repository/mock/settings.go
@@ -12,9 +12,9 @@ type SettingsRepository struct {
 	mock.Mock
 }
 
-func (m *SettingsRepository) Update(ctx context.Context, fn svcmodel.UpdateSettingsFunc) (svcmodel.Settings, error) {
+func (m *SettingsRepository) Update(ctx context.Context, fn svcmodel.UpdateSettingsFunc) error {
 	args := m.Called(ctx, fn)
-	return args.Get(0).(svcmodel.Settings), args.Error(1)
+	return args.Error(0)
 }
 
 func (m *SettingsRepository) Read(ctx context.Context) (svcmodel.Settings, error) {

--- a/service/service.go
+++ b/service/service.go
@@ -48,7 +48,7 @@ type userRepository interface {
 }
 
 type settingsRepository interface {
-	Update(ctx context.Context, fn model.UpdateSettingsFunc) (model.Settings, error)
+	Update(ctx context.Context, fn model.UpdateSettingsFunc) error
 	Read(ctx context.Context) (model.Settings, error)
 }
 

--- a/service/settings.go
+++ b/service/settings.go
@@ -35,23 +35,22 @@ func (s *SettingsService) Get(ctx context.Context, authUserID uuid.UUID) (model.
 	return settings, nil
 }
 
-func (s *SettingsService) Update(ctx context.Context, input model.UpdateSettingsInput, authUserID uuid.UUID) (model.Settings, error) {
+func (s *SettingsService) Update(ctx context.Context, input model.UpdateSettingsInput, authUserID uuid.UUID) error {
 	if err := s.authGuard.AuthorizeUserRoleAdmin(ctx, authUserID); err != nil {
-		return model.Settings{}, fmt.Errorf("authorizing user role: %w", err)
+		return fmt.Errorf("authorizing user role: %w", err)
 	}
 
-	settings, err := s.repository.Update(ctx, func(s model.Settings) (model.Settings, error) {
+	if err := s.repository.Update(ctx, func(s model.Settings) (model.Settings, error) {
 		if err := s.Update(input); err != nil {
 			return model.Settings{}, svcerrors.NewSettingsUnprocessableError().Wrap(err).WithMessage(err.Error())
 		}
 
 		return s, nil
-	})
-	if err != nil {
-		return model.Settings{}, fmt.Errorf("updating settings: %w", err)
+	}); err != nil {
+		return fmt.Errorf("updating settings: %w", err)
 	}
 
-	return settings, nil
+	return nil
 }
 
 func (s *SettingsService) GetGithubToken(ctx context.Context) (string, error) {

--- a/service/settings_test.go
+++ b/service/settings_test.go
@@ -35,7 +35,7 @@ func TestSettingsService_Update(t *testing.T) {
 			},
 			mockSetup: func(authSvc *svc.AuthorizationService, settingsRepo *repo.SettingsRepository) {
 				authSvc.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
-				settingsRepo.On("Update", mock.Anything, mock.Anything).Return(model.Settings{}, nil)
+				settingsRepo.On("Update", mock.Anything, mock.Anything).Return(nil)
 			},
 			expectErr: false,
 		},
@@ -51,7 +51,7 @@ func TestSettingsService_Update(t *testing.T) {
 			},
 			mockSetup: func(authSvc *svc.AuthorizationService, settingsRepo *repo.SettingsRepository) {
 				authSvc.On("AuthorizeUserRoleAdmin", mock.Anything, mock.Anything).Return(nil)
-				settingsRepo.On("Update", mock.Anything, mock.Anything).Return(model.Settings{}, svcerrors.NewSettingsUnprocessableError())
+				settingsRepo.On("Update", mock.Anything, mock.Anything).Return(svcerrors.NewSettingsUnprocessableError())
 			},
 			expectErr: true,
 		},
@@ -65,7 +65,7 @@ func TestSettingsService_Update(t *testing.T) {
 
 			tc.mockSetup(authSvc, settingsRepo)
 
-			_, err := settingsSvc.Update(context.Background(), tc.update, tc.userID)
+			err := settingsSvc.Update(context.Background(), tc.update, tc.userID)
 
 			if tc.expectErr {
 				assert.Error(t, err)

--- a/transport/handler/handler.go
+++ b/transport/handler/handler.go
@@ -48,7 +48,7 @@ type userService interface {
 }
 
 type settingsService interface {
-	Update(ctx context.Context, u svcmodel.UpdateSettingsInput, authUserID uuid.UUID) (svcmodel.Settings, error)
+	Update(ctx context.Context, u svcmodel.UpdateSettingsInput, authUserID uuid.UUID) error
 	Get(ctx context.Context, authUserID uuid.UUID) (svcmodel.Settings, error)
 	GetGithubWebhookSecret(ctx context.Context) (string, error)
 }

--- a/transport/handler/settings.go
+++ b/transport/handler/settings.go
@@ -15,17 +15,16 @@ func (h *Handler) updateSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s, err := h.SettingsSvc.Update(
+	if err := h.SettingsSvc.Update(
 		r.Context(),
 		model.ToSvcUpdateSettingsInput(req),
 		util.ContextAuthUserID(r),
-	)
-	if err != nil {
+	); err != nil {
 		util.WriteResponseError(w, resperrors.ToError(err))
 		return
 	}
 
-	util.WriteJSONResponse(w, http.StatusOK, model.ToSettings(s))
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *Handler) getSettings(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The client does not need the endpoints to return the updated entity when calling PATCH requests.

Also, the implementation is simpler when the service—especially the repository function—doesn't return the updated entity and follows the command/query principle...
