### PR TITLE
fix(github client): avoid fetching git tag when parsing tag deletion webhook

### DIFF
--- a/github/mock/client.go
+++ b/github/mock/client.go
@@ -53,7 +53,7 @@ func (c *Client) GenerateReleaseNotes(ctx context.Context, tkn svcmodel.GithubTo
 	return args.Get(0).(svcmodel.GithubReleaseNotes), args.Error(1)
 }
 
-func (c *Client) ParseTagDeletionWebhook(ctx context.Context, webhook svcmodel.GithubTagDeletionWebhookInput, tkn svcmodel.GithubToken, secret svcmodel.GithubWebhookSecret) (svcmodel.GithubRepo, svcmodel.GitTag, error) {
+func (c *Client) ParseTagDeletionWebhook(ctx context.Context, webhook svcmodel.GithubTagDeletionWebhookInput, tkn svcmodel.GithubToken, secret svcmodel.GithubWebhookSecret) (svcmodel.GithubTagDeletionWebhookOutput, error) {
 	args := c.Called(ctx, webhook, tkn, secret)
-	return args.Get(0).(svcmodel.GithubRepo), args.Get(1).(svcmodel.GitTag), args.Error(2) //nolint:gomnd
+	return args.Get(0).(svcmodel.GithubTagDeletionWebhookOutput), args.Error(1)
 }

--- a/github/model/model.go
+++ b/github/model/model.go
@@ -61,9 +61,16 @@ func ToSvcGithubRepo(repo *github.Repository, ownerSlug, repoSlug string) (svcmo
 	}, nil
 }
 
-func ToGithubReleaseNotes(notes *github.RepositoryReleaseNotes) svcmodel.GithubReleaseNotes {
+func ToSvcGithubReleaseNotes(notes *github.RepositoryReleaseNotes) svcmodel.GithubReleaseNotes {
 	return svcmodel.GithubReleaseNotes{
 		Title: notes.Name,
 		Notes: notes.Body,
+	}
+}
+
+func ToSvcGithubTagDeletionWebhookOutput(repo svcmodel.GithubRepo, tagName string) svcmodel.GithubTagDeletionWebhookOutput {
+	return svcmodel.GithubTagDeletionWebhookOutput{
+		Repo:    repo,
+		TagName: tagName,
 	}
 }

--- a/repository/mock/release.go
+++ b/repository/mock/release.go
@@ -62,7 +62,7 @@ func (m *ReleaseRepository) ReadLastDeploymentForRelease(ctx context.Context, re
 	return args.Get(0).(svcmodel.Deployment), args.Error(1)
 }
 
-func (m *ReleaseRepository) DeleteReleaseByGitTag(ctx context.Context, repo svcmodel.GithubRepo, tag svcmodel.GitTag) error {
-	args := m.Called(ctx, repo, tag)
+func (m *ReleaseRepository) DeleteReleaseByGitTag(ctx context.Context, repo svcmodel.GithubRepo, tagName string) error {
+	args := m.Called(ctx, repo, tagName)
 	return args.Error(0)
 }

--- a/repository/release.go
+++ b/repository/release.go
@@ -102,11 +102,11 @@ func (r *ReleaseRepository) UpdateRelease(
 	})
 }
 
-func (r *ReleaseRepository) DeleteReleaseByGitTag(ctx context.Context, repo svcmodel.GithubRepo, tag svcmodel.GitTag) error {
+func (r *ReleaseRepository) DeleteReleaseByGitTag(ctx context.Context, repo svcmodel.GithubRepo, tagName string) error {
 	return r.deleteRelease(ctx, r.dbpool, query.DeleteReleaseByGitTag, pgx.NamedArgs{
 		"ownerSlug":  repo.OwnerSlug,
 		"repoSlug":   repo.RepoSlug,
-		"gitTagName": tag.Name,
+		"gitTagName": tagName,
 	})
 }
 

--- a/service/model/release.go
+++ b/service/model/release.go
@@ -174,3 +174,8 @@ type GithubTagDeletionWebhookInput struct {
 	RawPayload []byte
 	Signature  string
 }
+
+type GithubTagDeletionWebhookOutput struct {
+	Repo    GithubRepo
+	TagName string
+}

--- a/service/release.go
+++ b/service/release.go
@@ -336,12 +336,12 @@ func (s *ReleaseService) DeleteReleaseOnGitTagRemoval(ctx context.Context, input
 		return svcerrors.NewGithubIntegrationNotEnabledError()
 	}
 
-	repo, tag, err := s.githubManager.ParseTagDeletionWebhook(ctx, input, github.Token, github.WebhookSecret)
+	output, err := s.githubManager.ParseTagDeletionWebhook(ctx, input, github.Token, github.WebhookSecret)
 	if err != nil {
-		return fmt.Errorf("processing webhook delete tag event: %w", err)
+		return fmt.Errorf("parsing webhook delete tag event: %w", err)
 	}
 
-	if err := s.repo.DeleteReleaseByGitTag(ctx, repo, tag); err != nil {
+	if err := s.repo.DeleteReleaseByGitTag(ctx, output.Repo, output.TagName); err != nil {
 		return fmt.Errorf("deleting release by git tag: %w", err)
 	}
 

--- a/service/release_test.go
+++ b/service/release_test.go
@@ -908,7 +908,7 @@ func TestReleaseService_DeleteReleaseOnGitTagRemoval(t *testing.T) {
 					Token:         "token",
 					WebhookSecret: "secret",
 				}, nil)
-				github.On("ParseTagDeletionWebhook", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.GithubRepo{}, model.GitTag{}, nil)
+				github.On("ParseTagDeletionWebhook", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.GithubTagDeletionWebhookOutput{}, nil)
 				releaseRepo.On("DeleteReleaseByGitTag", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			wantErr: false,
@@ -940,7 +940,7 @@ func TestReleaseService_DeleteReleaseOnGitTagRemoval(t *testing.T) {
 					Token:         "token",
 					WebhookSecret: "secret",
 				}, nil)
-				github.On("ParseTagDeletionWebhook", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.GithubRepo{}, model.GitTag{}, svcerrors.NewInvalidGithubTagDeletionWebhookError())
+				github.On("ParseTagDeletionWebhook", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(model.GithubTagDeletionWebhookOutput{}, svcerrors.NewInvalidGithubTagDeletionWebhookError())
 			},
 			wantErr: true,
 		},

--- a/service/service.go
+++ b/service/service.go
@@ -82,7 +82,7 @@ type releaseRepository interface {
 	ReadRelease(ctx context.Context, releaseID id.Release) (model.Release, error)
 	ReadReleaseForProject(ctx context.Context, projectID id.Project, releaseID id.Release) (model.Release, error)
 	DeleteRelease(ctx context.Context, releaseID id.Release) error
-	DeleteReleaseByGitTag(ctx context.Context, repo model.GithubRepo, tag model.GitTag) error
+	DeleteReleaseByGitTag(ctx context.Context, repo model.GithubRepo, tagName string) error
 	ListReleasesForProject(ctx context.Context, projectID id.Project) ([]model.Release, error)
 	UpdateRelease(
 		ctx context.Context,
@@ -141,7 +141,7 @@ type githubManager interface {
 		input model.GithubTagDeletionWebhookInput,
 		tkn model.GithubToken,
 		secret model.GithubWebhookSecret,
-	) (model.GithubRepo, model.GitTag, error)
+	) (model.GithubTagDeletionWebhookOutput, error)
 }
 
 type emailSender interface {


### PR DESCRIPTION
Since the tag no longer exists when a tag deletion webhook is received, fetching it will result in an error.